### PR TITLE
chore(release): caller → releasegraph@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   release:
-    uses: redtidev1918/release-infra/.github/workflows/reusable-release.yml@v1
+    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@v1
     with:
       version: ${{ inputs.version || '' }}
       dry_run: ${{ github.event_name == 'pull_request' || inputs.dry_run || false }}


### PR DESCRIPTION
## chore(release): pin caller to redtidev1918/releasegraph@v1

The reusable release workflow was renamed `release-infra` → `releasegraph`. New callers must reference the canonical path; the old path only keeps working through GitHub's repository redirect.

- `uses: redtidev1918/release-infra/.github/workflows/reusable-release.yml@v1`
- `uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@v1`

No release semantics change: same `v1` stable tag, same workflow inputs/outputs. The schedule remains a same-version reconcile/repair trigger (healthy version = no-op); it never manufactures releases.

Refs: [MIGRATION.md](https://github.com/redtidev1918/releasegraph/blob/v1/docs/MIGRATION.md#compatibility)
