### PR TITLE
chore(release-infra): bump ReleaseGraph to v1.4.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@v1
+    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@6b3843bfdd73338831630e004eaf3535b84dcfd3 # ReleaseGraph v1.4.3
     with:
       version: ${{ inputs.version || '' }}
       dry_run: ${{ github.event_name == 'pull_request' || inputs.dry_run || false }}


### PR DESCRIPTION
Pins the release infrastructure to `v1.4.3` (commit `6b3843bfdd73338831630e004eaf3535b84dcfd3`).

Opened by `releasegraph rollout` after the canary repository completed a release lifecycle on this version.
Reverting this pull request returns the repository to its previous pin.