### PR TITLE
chore(release-infra): bump ReleaseGraph to v1.4.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@f0b1da0a62a7f4f26eab36353a58c6254b751c07 # ReleaseGraph v1.4.4
+    uses: redtidev1918/releasegraph/.github/workflows/reusable-release.yml@f4e4d308e145b6c663374a71068da4c3b6526254 # ReleaseGraph v1.4.7
     with:
       version: ${{ inputs.version || '' }}
       dry_run: ${{ github.event_name == 'pull_request' || inputs.dry_run || false }}


### PR DESCRIPTION
Pins the release infrastructure to `v1.4.7` (commit `f4e4d308e145b6c663374a71068da4c3b6526254`).

Opened by `releasegraph rollout` after the canary repository completed a release lifecycle on this version.
Reverting this pull request returns the repository to its previous pin.