### PR TITLE
docs: docs 目录对齐中英平行结构，补齐中文开发者文档，接入托管下载页链路

### DIFF
--- a/.github/scripts/download-page.json
+++ b/.github/scripts/download-page.json
@@ -1,0 +1,3 @@
+{
+  "displayName": "DAViewer"
+}

--- a/.github/scripts/update_download_page.py
+++ b/.github/scripts/update_download_page.py
@@ -1,17 +1,39 @@
 #!/usr/bin/env python3
-"""Generate docs/download.md from the latest GitHub release.
+"""生成下载页：中文主页面 + 英文镜像（同一份资产表）。
 
-Run by the ReleaseGraph `post_publish` hook in .release-policy.yml as part of
-the release transaction, so the page always points at the newest assets. Idempotent: no release change
-means no diff, so it won't spam commits.
+    python3 .github/scripts/update_download_page.py [owner/repo]
+
+产出：
+    docs/download.md       中文主页面
+    docs/en/download.md    英文镜像
+
+数据取自 GitHub 最新 Release。无 Release 变化时输出不变，因此不会产生空提交。
+CI 由 .github/workflows/update-download-page.yml 在 `release: published` 时触发；
+也可本地手动运行（需要已登录的 gh CLI）。
+
+可选配置（**非托管**文件，各仓库自行维护）：
+    .github/scripts/download-page.json
+        { "displayName": "DAViewer", "previewFile": "docs/download-preview.md" }
+    displayName  页面标题中显示的产品名，默认取仓库名
+    previewFile  手写预览片段；存在时注入中文页（放应用截图等），默认 docs/download-preview.md
 """
 import json
 import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
-REPO = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("GITHUB_REPOSITORY", "")
+# docsite-managed-file: update_download_page.py
+# docsite-managed-version: 1
+
+CONFIG = Path(".github/scripts/download-page.json")
+DEFAULT_PREVIEW = "docs/download-preview.md"
+
+EN_OS = {"通用": "All platforms", "Windows": "Windows", "macOS": "macOS",
+         "Linux": "Linux", "Android": "Android"}
+EN_TABLE_HEAD = "| Platform | File | Size | Download |"
+ZH_TABLE_HEAD = "| 平台 | 文件 | 大小 | 下载 |"
 
 
 def api(url: str) -> dict:
@@ -22,6 +44,15 @@ def infer_repo() -> str:
     out = subprocess.check_output(["git", "remote", "get-url", "origin"]).decode().strip()
     m = re.search(r"(?:github\.com[:/])([^/]+)/([^/.]+)", out)
     return f"{m.group(1)}/{m.group(2)}" if m else ""
+
+
+def load_config() -> dict:
+    if CONFIG.is_file():
+        try:
+            return json.loads(CONFIG.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            print(f"warning: {CONFIG} 不是合法 JSON（{exc}），使用默认值", file=sys.stderr)
+    return {}
 
 
 def platform_of(fn: str) -> tuple:
@@ -48,70 +79,93 @@ def platform_of(fn: str) -> tuple:
 
 
 def main() -> int:
-    global REPO
-    if not REPO:
-        REPO = infer_repo()
-    if not REPO or "/" not in REPO:
+    repo = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("GITHUB_REPOSITORY", "")
+    if not repo:
+        repo = infer_repo()
+    if not repo or "/" not in repo:
         print("cannot determine owner/repo", file=sys.stderr)
         return 1
 
+    cfg = load_config()
+    project = repo.split("/")[1]
+    display = cfg.get("displayName") or project
+    preview_path = Path(cfg.get("previewFile") or DEFAULT_PREVIEW)
+
     try:
-        rel = api(f"repos/{REPO}/releases/latest")
+        rel = api(f"repos/{repo}/releases/latest")
     except subprocess.CalledProcessError:
         print("no latest release", file=sys.stderr)
         return 1
 
     tag = rel.get("tag_name", "")
-    name = rel.get("name") or tag
     published = (rel.get("published_at") or "")[:10]
     assets = rel.get("assets", [])
-    project = REPO.split("/")[1]
-    # 仓库名（daviewer）与产品显示名（DAViewer）不一致；其余仓库按原样显示。
-    display = {"daviewer": "DAViewer"}.get(project, project)
 
-    lines = [
-        f"# 📥 下载 {display}",
-        "",
-        "本页由 GitHub Actions 在每次发版时**自动更新**，始终指向最新 Release。",
-        "",
-        f"## 最新版本：`{tag}`（{published}）",
-        "",
-        f"👉 [查看 Release 说明与校验和]({rel.get('html_url', '')})",
-        "",
-    ]
+    def head(title_zh: bool) -> list:
+        if title_zh:
+            return [
+                f"# 📥 下载 {display}",
+                "",
+                "**语言 / Language:** 中文 · [English](/en/download.md)",
+                "",
+                "本页由 GitHub Actions 在每次发版时**自动更新**，始终指向最新 Release。",
+                "",
+                f"## 最新版本：`{tag}`（{published}）",
+                "",
+                f"👉 [查看 Release 说明与校验和]({rel.get('html_url', '')})",
+                "",
+            ]
+        return [
+            f"# 📥 Download {display}",
+            "",
+            "**Language / 语言:** [中文](/download.md) · English",
+            "",
+            "This page is **generated automatically** by GitHub Actions on every release "
+            "and always points at the latest one.",
+            "",
+            f"## Latest version: `{tag}` ({published})",
+            "",
+            f"👉 [Release notes and checksums]({rel.get('html_url', '')})",
+            "",
+        ]
 
-    # 可选的手写预览段：docs/download-preview.md（稳定文件，不被生成器覆盖）。
-    # 每次发版重新生成时会把它的内容注入下载页（放应用截图等）。
-    _preview_path = "docs/download-preview.md"
-    if os.path.isfile(_preview_path):
-        _preview = open(_preview_path, encoding="utf-8").read().strip()
-        if _preview:
-            lines.append(_preview)
-            lines.append("")
+    lines_zh = head(True)
+    lines_en = head(False)
 
-    if assets:
-        rows = []
-        for a in assets:
-            os_name, arch = platform_of(a["name"])
-            size = a.get("size", 0)
-            size_s = f"{size/1048576:.1f} MB" if size >= 1048576 else f"{size/1024:.0f} KB"
-            rows.append((os_name, arch, a["name"], size_s, a["browser_download_url"]))
-        rows.sort(key=lambda r: (r[0], r[1], r[2]))
+    # 手写预览片段只进中文页（内容通常为中文说明与截图）。
+    if preview_path.is_file():
+        preview = preview_path.read_text(encoding="utf-8").strip()
+        if preview:
+            lines_zh += [preview, ""]
 
-        lines.append("| 平台 | 文件 | 大小 | 下载 |")
-        lines.append("|---|---|---|---|")
-        for os_name, arch, fn, size_s, url in rows:
-            plat = os_name + (f" · {arch}" if arch else "")
-            lines.append(f"| {plat} | `{fn}` | {size_s} | [⬇️ 下载]({url}) |")
-        lines.append("")
+    rows = []
+    for a in assets:
+        os_name, arch = platform_of(a["name"])
+        size = a.get("size", 0)
+        size_s = f"{size / 1048576:.1f} MB" if size >= 1048576 else f"{size / 1024:.0f} KB"
+        rows.append((os_name, arch, a["name"], size_s, a["browser_download_url"]))
+    rows.sort(key=lambda r: (r[0], r[1], r[2]))
+
+    if rows:
+        lines_zh += [ZH_TABLE_HEAD, "|---|---|---|---|"]
+        lines_zh += [f"| {os_name + (f' · {arch}' if arch else '')} | `{fn}` | {size_s} "
+                     f"| [⬇️ 下载]({url}) |" for os_name, arch, fn, size_s, url in rows]
+        lines_zh.append("")
+
+        lines_en += [EN_TABLE_HEAD, "|---|---|---|---|"]
+        lines_en += [f"| {EN_OS.get(os_name, os_name) + (f' · {arch}' if arch else '')} "
+                     f"| `{fn}` | {size_s} | [⬇️ Download]({url}) |"
+                     for os_name, arch, fn, size_s, url in rows]
+        lines_en.append("")
     else:
-        lines.append("> 本仓库没有附带二进制资产；安装方式见文档。")
-        lines.append("")
+        lines_zh += ["> 本仓库没有附带二进制资产；安装方式见文档。", ""]
+        lines_en += ["> This repository ships no binary assets; see the docs for installation.", ""]
 
-    os.makedirs("docs", exist_ok=True)
-    with open("docs/download.md", "w", encoding="utf-8") as fh:
-        fh.write("\n".join(lines))
-    print(f"docs/download.md <- {project} {tag} ({len(assets)} assets)")
+    Path("docs").mkdir(parents=True, exist_ok=True)
+    Path("docs/en").mkdir(parents=True, exist_ok=True)
+    Path("docs/download.md").write_text("\n".join(lines_zh), encoding="utf-8")
+    Path("docs/en/download.md").write_text("\n".join(lines_en), encoding="utf-8")
+    print(f"docs/download.md + docs/en/download.md <- {repo} {tag} ({len(rows)} assets)")
     return 0
 
 

--- a/.github/scripts/update_download_page.py
+++ b/.github/scripts/update_download_page.py
@@ -13,9 +13,11 @@ CI 由 .github/workflows/update-download-page.yml 在 `release: published` 时�
 
 可选配置（**非托管**文件，各仓库自行维护）：
     .github/scripts/download-page.json
-        { "displayName": "DAViewer", "previewFile": "docs/download-preview.md" }
+        { "displayName": "DAViewer", "previewFile": "docs/download-preview.md", "linkBase": "" }
     displayName  页面标题中显示的产品名，默认取仓库名
     previewFile  手写预览片段；存在时注入中文页（放应用截图等），默认 docs/download-preview.md
+    linkBase     页面内互链的站点路径前缀。默认 ""（Pages 直接上传 ./docs，docs 即站点根）；
+                 若站点是「拼接 _site」模式且把 docs/ 作为子目录发布，填 "/docs"
 """
 import json
 import os
@@ -25,7 +27,7 @@ import sys
 from pathlib import Path
 
 # docsite-managed-file: update_download_page.py
-# docsite-managed-version: 1
+# docsite-managed-version: 2
 
 CONFIG = Path(".github/scripts/download-page.json")
 DEFAULT_PREVIEW = "docs/download-preview.md"
@@ -90,6 +92,8 @@ def main() -> int:
     project = repo.split("/")[1]
     display = cfg.get("displayName") or project
     preview_path = Path(cfg.get("previewFile") or DEFAULT_PREVIEW)
+    # 站点内互链前缀：docs/ 即站点根时为 ""，docs/ 作为子目录发布时为 "/docs"。
+    base = (cfg.get("linkBase") or "").rstrip("/")
 
     try:
         rel = api(f"repos/{repo}/releases/latest")
@@ -106,7 +110,7 @@ def main() -> int:
             return [
                 f"# 📥 下载 {display}",
                 "",
-                "**语言 / Language:** 中文 · [English](/en/download.md)",
+                f"**语言 / Language:** 中文 · [English]({base}/en/download.md)",
                 "",
                 "本页由 GitHub Actions 在每次发版时**自动更新**，始终指向最新 Release。",
                 "",
@@ -118,7 +122,7 @@ def main() -> int:
         return [
             f"# 📥 Download {display}",
             "",
-            "**Language / 语言:** [中文](/download.md) · English",
+            f"**Language / 语言:** [中文]({base}/download.md) · English",
             "",
             "This page is **generated automatically** by GitHub Actions on every release "
             "and always points at the latest one.",

--- a/.github/workflows/update-download-page.yml
+++ b/.github/workflows/update-download-page.yml
@@ -1,0 +1,44 @@
+# docsite-managed-file: update-download-page.yml
+# docsite-managed-version: 1
+# docsite: managed file, run `python3 docsite.py update` to refresh.
+# 每次发版后刷新下载页：docs/download.md（中）与 docs/en/download.md（英）。
+#
+# 不写死分支：检出仓库默认分支，保证 Release 事件下也把提交落到主干。
+name: Update download page
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-download-page
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Regenerate download pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/update_download_page.py "${{ github.repository }}"
+
+      - name: Commit if changed
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "download page already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/download.md docs/en/download.md
+          git commit -m "docs: refresh download page (${{ github.event.release.tag_name || 'manual' }})"
+          git push

--- a/README.en.md
+++ b/README.en.md
@@ -136,7 +136,7 @@ passwords, and provider security checks stay on DeviantArt's official page insid
 the app's embedded WebView. After the callback, every feature uses that one
 OAuth identity plus the WebView's web session; there is no second web sign-in to
 synchronize. Signed-out state is onboarding, not a feed error. See
-[Architecture](docs/architecture.md) for the full boundaries.
+[Architecture](docs/en/architecture.md) for the full boundaries.
 
 ## References & acknowledgements
 
@@ -220,11 +220,11 @@ proxy while restricted networks receive the relevant recovery steps.
 
 Apps launched from Finder usually do not inherit terminal variables. On macOS
 12/13 an app-only proxy cannot be injected into the hidden browser adapter, so
-use the macOS system proxy. See [Networking and proxy](docs/networking.md) for
+use the macOS system proxy. See [Networking and proxy](docs/en/networking.md) for
 the full priority, platform matrix, and troubleshooting flow.
 
 Environment variables for proxying `flutter pub get` and Gradle builds are in
-[Build notes](docs/build.md#proxying-builds).
+[Build notes](docs/en/build.md#proxying-builds).
 
 ## Build & release
 
@@ -246,7 +246,7 @@ flutter build windows --release      # Windows app
 
 Signing, the pinned toolchain (AGP / Gradle / Kotlin / flutter_inappwebview), and
 the macOS unsigned-preview contract are detailed in
-[Build notes](docs/build.md).
+[Build notes](docs/en/build.md).
 
 ## Home & sign-in state
 
@@ -289,7 +289,7 @@ never block a live sign-in when they cannot be stored or cleared.
   just macOS unlocking your own keychain; the app never collects or uploads
   your password.
 
-See [Authentication and session recovery](docs/authentication.md) for the full
+See [Authentication and session recovery](docs/en/authentication.md) for the full
 state contract.
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,30 @@
 # 🖼️ DAViewer 文档中心
 
+**语言 / Language:** 中文 · [English](/en/)
+
 项目文档索引。面向用户的介绍与安装说明见根目录
 [README.md（中文）](https://github.com/redtidev1918/daviewer/blob/main/README.md) 与
-[README.en.md（English）](https://github.com/redtidev1918/daviewer/blob/main/README.en.md)；
-本站（docs/）存放更深层的开发与架构说明。面向用户页面（本页、下载页）为中文，
-开发者文档正文按约定使用英文。
+[README.en.md（English）](https://github.com/redtidev1918/daviewer/blob/main/README.en.md)。
+
+本站按账号统一文档规范组织：`docs/` 根为**中文**，`docs/en/` 为**英文**，
+中英同名页一一对应（下表可直接对照）。
 
 ## 📥 下载
 
-Android / Windows / macOS 安装包见 [📥 下载页](download.md)，始终指向最新 Release。
+Android / Windows / macOS 安装包见 [📥 下载页](download.md)，始终指向最新 Release；
+英文版见 [Download](/en/download.md)。
 
-## 文档
+## 开发者文档
 
-- [Architecture — 架构设计](architecture.md)：SDK 与应用边界、作品数据流、相关推荐
-  状态、手势所有权、认证、应用内状态与发布约定。
-- [Authentication and session recovery — 认证与会话恢复](authentication.md)：
-  单 OAuth 模型、冷启动恢复、macOS 钥匙串存储、成人内容设置。
-- [Networking and proxy — 网络与代理](networking.md)：运行时优先级、持久化手动设置、
-  各平台 WebView 覆盖、连通性测试与恢复。
-- [Web adapter — 网页适配器](web_adapter.md)：逆向网页接口的兼容约定（端点注册表、
-  回退策略与变更排查手册）。
-- [Build notes — 构建与发布](build.md)：固定工具链、Release/CI 约定、pub get 与
-  Gradle 构建的代理配置。
+| 中文 | English |
+| --- | --- |
+| [架构说明](architecture.md)：SDK 与应用边界、作品数据流、相关内容状态、手势归属、认证、应用内状态与发布约定 | [Architecture](en/architecture.md) |
+| [网页适配器 —— 兼容性契约](web_adapter.md)：逆向网页接口的兼容约定（端点注册表、回退策略与变更排查手册） | [Web adapter](en/web_adapter.md) |
+| [认证与会话恢复](authentication.md)：单 OAuth 模型、冷启动恢复、macOS 钥匙串存储、Cookie 导入导出、成人内容 | [Authentication and session recovery](en/authentication.md) |
+| [网络与代理](networking.md)：运行时优先级、各平台 WebView 覆盖、连通性测试与恢复 | [Networking and proxy](en/networking.md) |
+| [构建说明](build.md)：固定工具链、Release/CI 约定、pub get 与 Gradle 构建的代理配置 | [Build notes](en/build.md) |
+
+## 参与与合规
 
 参与贡献见 [CONTRIBUTING.md](https://github.com/redtidev1918/daviewer/blob/main/CONTRIBUTING.md)；
 安全漏洞请走 [SECURITY.md](https://github.com/redtidev1918/daviewer/blob/main/SECURITY.md)；
@@ -34,6 +37,7 @@ Android / Windows / macOS 安装包见 [📥 下载页](download.md)，始终指
 
 ## 约定
 
-- 面向用户的页面保持中文，必要时提供中英双语；开发者文档正文用英文。
+- `docs/` 根为中文，`docs/en/` 为英文，同名页一一对应；改动其中一页时请同步另一页。
 - 文档只描述当前行为；历史决策见
-  [CHANGELOG.md](https://github.com/redtidev1918/daviewer/blob/main/CHANGELOG.md) 与 Release 历史。
+  [CHANGELOG.md](https://github.com/redtidev1918/daviewer/blob/main/CHANGELOG.md) 与
+  [RELEASE_NOTES.md](https://github.com/redtidev1918/daviewer/blob/main/RELEASE_NOTES.md)。

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,11 +1,19 @@
 - 开始
-  - [文档中心](#/)
-  - [📥 下载](download.md)
+  - [文档中心](/)
+  - [📥 下载](/download.md)
 - 架构与设计
-  - [DAViewer architecture](architecture.md)
-  - [Web adapter — compatibility contract](web_adapter.md)
+  - [架构说明](/architecture.md)
+  - [网页适配器 —— 兼容性契约](/web_adapter.md)
 - 认证与网络
-  - [Authentication and session recovery](authentication.md)
-  - [Networking and proxy](networking.md)
+  - [认证与会话恢复](/authentication.md)
+  - [网络与代理](/networking.md)
 - 构建与发布
-  - [DAViewer build notes](build.md)
+  - [构建说明](/build.md)
+- English
+  - [Documentation](/en/)
+  - [📥 Download](/en/download.md)
+  - [Architecture](/en/architecture.md)
+  - [Web adapter — compatibility contract](/en/web_adapter.md)
+  - [Authentication and session recovery](/en/authentication.md)
+  - [Networking and proxy](/en/networking.md)
+  - [Build notes](/en/build.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,211 +1,101 @@
-# DAViewer architecture
+# DAViewer 架构说明
 
-This document defines the boundaries that are easiest to blur when fixing feed,
-detail, authentication, media, and release bugs.
+> English: [DAViewer architecture](/en/architecture.md)
 
-## SDK and app boundary
+本文界定在处理信息流、详情页、认证、媒体与发版问题最容易模糊的那几条边界。
 
-- **DAKit** owns OAuth, official DeviantArt API transports and DTO mapping,
-  domain models, secure token storage, and background transfers.
-- **DAViewer** owns web-session endpoints that have no official equivalent,
-  source fallback policy, native navigation and gestures, UI state, and
-  host-level caching.
-- Web responses are mapped into DAKit domain models before entering feature
-  code. Features must not maintain a second artwork model.
+## SDK 与应用的分界
 
-Before adding an app workaround, verify whether the official response was
-mapped incorrectly. Fix mapping and transport contracts in DAKit; fix source
-composition, sparse-data hydration, caching, and presentation in DAViewer.
+- **DAKit** 负责 OAuth、官方 DeviantArt API 传输与 DTO 映射、领域模型、凭据安全存储与后台传输。
+- **DAViewer** 负责官方 API 没有等价能力的网页会话接口、数据源回退策略、原生导航与手势、UI 状态，以及宿主侧缓存。
+- 网页响应一律先映射为 DAKit 领域模型，再进入业务代码。业务层不得维护第二套作品模型。
 
-## Artwork data flow
+在给应用层加绕行方案之前，先确认是不是官方响应被映射错了。映射与传输契约的问题在 DAKit 修；数据源组合、稀疏数据补全、缓存与展示的问题在 DAViewer 修。
+
+## 作品数据流
 
 ```text
-official/web list source
-        ↓ (possibly sparse Artwork)
+官方 / 网页列表数据源
+        ↓（可能是稀疏的 Artwork）
 ArtworkStore.putAll
         ↓
-feed card → detail route → artworkDetailProvider
-                            ↓ missing detail-only field
-                  deviation/metadata adapter
+信息流卡片 → 详情路由 → artworkDetailProvider
+                            ↓ 缺少仅详情页才有的字段
+                  deviation/metadata 适配器
                             ↓
                     ArtworkStore.setTags
 ```
 
-List endpoints may legally omit fields such as tags, and `deviation/{id}` does
-not reliably add them back. An empty list therefore does not prove that a work
-is tagless until the dedicated `deviation/metadata` endpoint confirms it.
-`ArtworkStore` records that resolution separately, including a confirmed empty
-result, and preserves hydrated tags when a later feed refresh contains a sparse
-object.
+列表接口合法地省略 tags 之类的字段，而 `deviation/{id}` 并不总能补回来。因此在专用端点 `deviation/metadata` 确认之前，空列表**不能**证明作品没有标签。`ArtworkStore` 单独记录这次解析结果（包括「确认无标签」这一结论），并在后续信息流刷新带回稀疏对象时保留已补全的标签。
 
-Rules:
+规则：
 
-1. Do not make every feed eagerly fetch every detail; hydrate only the field the
-   visible screen needs.
-2. Do not replace a rich cached object with a sparse list object without a merge
-   rule.
-3. Cache a confirmed empty result so genuinely tagless works do not refetch on
-   every visit.
-4. A hydration failure may hide that optional section, but must not make the
-   artwork detail page unusable.
+1. 不要让每个信息流都急切拉取全部详情；只补当前可见界面真正需要的字段。
+2. 没有合并规则时，不要用稀疏的列表对象替换缓存中的完整对象。
+3. 把「确认无标签」的结果也缓存，避免真正无标签的作品每次访问都重新请求。
+4. 补全失败可以隐藏该可选区块，但不得让作品详情页整体不可用。
 
-### Preview-card presentation
+### 预览卡片呈现
 
-All artwork feeds use the shared `ArtworkCard` and the preview-aspect helper.
-The card is a column: the image keeps its natural aspect ratio (extreme
-landscape media is capped at 1.6:1 on phone-width viewports, 2:1 on desktop,
-with `BoxFit.cover` cropping the outer edges so the subject stays useful at
-thumbnail size), and the title/author render **below** the image as a normal
-card section — never as an overlay on top of the artwork. New feed surfaces
-must reuse the card instead of restoring a fixed-height overlay. The GIF /
-multi-image badges remain positioned on the image itself.
+所有作品信息流共用 `ArtworkCard` 与预览宽高比辅助函数。卡片是纵向结构：图片保持自身宽高比（手机宽度视口下超宽媒体上限 1.6:1，桌面 2:1，用 `BoxFit.cover` 裁掉外侧边缘，保证缩略图尺寸下主体仍可辨认），标题与作者作为普通卡片区块渲染在图片**下方**，绝不叠在作品之上。新的信息流界面必须复用该卡片，不得恢复固定高度的覆盖层。GIF / 多图角标仍定位在图片本身上。
 
-## Related-content state
+## 相关内容状态
 
-Website recommendation data has two supported server-rendered shapes: the
-current streamed `window.__RCACHE__.relatedContent` payload and the legacy
-normalized `window.__INITIAL_STATE__` metadata/entities. The streamed cache is
-preferred when complete, then parsing falls back to the legacy state. A missing
-`currentBiMetadata` entry or missing normalized entities is inconclusive, not a
-confirmed empty recommendation set. An empty success is shown only when the
-website parse and official fallback both finish without errors.
+网站推荐数据有两种受支持的服务端渲染形态：当前的流式 `window.__RCACHE__.relatedContent` 负载，以及旧的归一化 `window.__INITIAL_STATE__` metadata/entities。流式缓存完整时优先使用，否则解析回退到旧状态。缺少 `currentBiMetadata` 条目或缺少归一化实体属于**无法判定**，不等于「确认没有相关推荐」。只有当网站解析与官方回退都无错误地结束，才展示空结果。
 
-Related **artwork** comes from the website source when available (it can diverge
-from the legacy preview) and falls back to the official `browse/morelikethis`
-preview. Featured/suggested **collections** exist only in the official preview,
-so `moreLikeThisProvider` always fetches the official result and merges it with
-the website artwork (`mergeMoreLikeThisResult`); the collection rails therefore
-show consistently instead of disappearing whenever the website source happens
-to return artwork.
+相关**作品**在可用时取自网页数据源（它可能与旧预览不同），并回退到官方 `browse/morelikethis` 预览。精选/推荐**合集**只存在于官方预览中，因此 `moreLikeThisProvider` 总是请求官方结果并与网页作品合并（`mergeMoreLikeThisResult`）；这样合集栏目能稳定展示，而不会因为网页数据源偶尔返回作品就整体消失。
 
-Refreshing related content is one awaited operation. Existing cards remain
-visible during it, and completion must report one of three outcomes: changed,
-unchanged, or still empty. Source failures retain their network, session,
-service, or page-format classification instead of being masked by an empty
-fallback.
+刷新相关内容是一次可等待的操作。期间已有卡片保持可见，结束时必须报告三种结果之一：已变化、未变化、仍为空。数据源失败要保留其网络、会话、服务或页面格式分类，不能被空回退掩盖。
 
-Provider/parser names and raw exception messages are diagnostic data. User copy
-describes only the outcome and next action (checking, updated, unchanged, no
-result, sign in, check network, or try later).
+Provider/解析器名称与原始异常信息属于诊断数据。用户可见文案只描述结果与下一步（检查中、已更新、未变化、无结果、请登录、检查网络、稍后再试）。
 
-## Collection contents and artist discovery
+## 合集内容与作者发现
 
-**Collection full contents** (`WebCollectionContentsFetcher`): the official API
-only accepts a UUID `folderid`, while the preview exposes a numeric id, so there
-is no official full-contents path. DAViewer reads the website's own
-`_puppy/dashared/gallection/contents` JSON endpoint when a web session (Cookie +
-CSRF) is available, falling back to the server-rendered page
-(`deviantart.com/{username}/favourites/{folderId}?page=N`, which is public and
-needs no session) otherwise. Both carry the same deviation shape, so the mapping
-reuses `WebDeviationMapper.mapDeviation`. The UI shows the preview deviations
-instantly and swaps in the full list when ready, with an "open on the web"
-fallback.
+**合集完整内容**（`WebCollectionContentsFetcher`）：官方 API 只接受 UUID 形式的 `folderid`，而预览暴露的是数字 id，因此不存在官方完整内容通道。当有网页会话（Cookie + CSRF）时，DAViewer 读取网站自身的 `_puppy/dashared/gallection/contents` JSON 接口；否则回退到服务端渲染页面（`deviantart.com/{username}/favourites/{folderId}?page=N`，公开、无需会话）。两者作品结构相同，因此映射复用 `WebDeviationMapper.mapDeviation`。界面先立即展示预览里的作品，就绪后替换为完整列表，并提供「在网页中打开」作为兜底。
 
-**Collection covers**: the "More Like This" preview only sometimes carries a
-collection thumbnail. When it does not, the collection card lazily resolves the
-cover from `gallection/contents` (`collectionCoverProvider`), so cards do not
-stay blank; the folder-icon placeholder is only the last resort.
+**合集封面**：「More Like This」预览只有时携带合集缩略图。未携带时，合集卡片通过 `gallection/contents` 惰性解析封面（`collectionCoverProvider`），避免卡片长期空白；文件夹图标占位只是最后手段。
 
-**Watching a collection is not implemented.** The official API can watch a
-*user* (`user/watch`), not a specific collection/folder; a collection watch
-exists only in an undocumented web surface. Until that is reverse-engineered
-(web-session work, out of DAKit), collection cards open the collection natively
-but offer no follow action.
+**合集关注未实现。** 官方 API 能关注**用户**（`user/watch`），不能关注某个合集/文件夹；合集关注只存在于未公开的网页接口。在其被逆向（属网页会话工作，不在 DAKit 范围）之前，合集卡片可以原生打开合集，但不提供关注操作。
 
-**More from this artist** (`MoreFromArtistSection`): the author's other recent
-works, read from the official `gallery/{username}` first page. This is the
-cleanly available "artist discovery" path.
+**更多来自这位作者**（`MoreFromArtistSection`）：读取作者在官方 `gallery/{username}` 首页的其他近期作品。这是干净可用的「作者发现」路径。
 
-**Similar artists** (`SimilarArtistsSection`): DeviantArt has no public
-similar-artists endpoint — the official API only offers `browse/morelikethis`
-(deviations + collections), and the website's `biMetadata` `type: "artist"` hint
-is BI tracking (the author's account type), not a recommendation payload. The
-real "similar deviants" list streams post-hydration from an undocumented
-endpoint (absent from `__INITIAL_STATE__`, `__RCACHE__`, and `dadeviation/init`).
-DAViewer therefore derives similar artists from the "More Like This" artwork
-authors (`similarArtistsFrom`): artists whose work the recommendation engine
-surfaced as related are the honest equivalent. A future dedicated source would
-be a web-session reverse-engineering effort and must stay out of DAKit.
+**相似作者**（`SimilarArtistsSection`）：DeviantArt 没有公开的相似作者接口——官方 API 只有 `browse/morelikethis`（作品 + 合集），而网站 `biMetadata` 里 `type: "artist"` 是 BI 埋点（作者的账号类型），不是推荐负载。真正的「相似用户」列表来自补全后的未公开接口流式返回（在 `__INITIAL_STATE__`、`__RCACHE__` 与 `dadeviation/init` 中都找不到）。因此 DAViewer 从「More Like This」作品作者推导相似作者（`similarArtistsFrom`）：推荐引擎认定为相关的作品，其作者就是诚实的等价物。未来若有专用数据源，那属于网页会话逆向工作，必须留在 DAKit 之外。
 
-## Gesture ownership
+## 手势归属
 
-Artwork browsing and image panning share horizontal movement, so ownership is
-state-dependent:
+作品浏览与图片平移共享水平位移，因此归属取决于状态：
 
-- At 1x zoom, the outer viewer may recognize a horizontal artwork-navigation
-  gesture.
-- Above 1x zoom, every outer horizontal callback must be `null`; even a lone
-  cancel callback registers a competing recognizer and can steal mobile pans.
-- Multi-image paging consumes movement first. Artwork navigation begins only
-  after a further edge swipe at the first or last internal page.
-- Gesture tests must assert both the intended movement and the absence of an
-  unintended artwork-navigation callback.
+- 1x 缩放时，外层查看器可以识别水平作品切换手势。
+- 缩放大于 1x 时，外层所有水平回调必须为 `null`；哪怕只注册一个 cancel 回调，也会引入竞争的识别器并可能抢走移动端的平移。
+- 多图翻页优先消费位移。只有在内部首页/末页继续向边缘滑动时，才开始作品切换。
+- 手势测试必须同时断言「预期位移发生」与「未触发意外的作品切换回调」。
 
-## Authentication boundary
+## 认证边界
 
-The app has one user identity: OAuth for Home, favourites, watch, galleries,
-downloads, and every other official API. Signed-out state is onboarding, not a
-feed error. Each visible attempt owns one OAuth/PKCE transaction and opens the
-official login page in the app's embedded WebView (with a desktop User-Agent).
-DeviantArt's page owns account selection, passwords, registration, social
-providers, and security checks. The `dakit://oauth/callback` is intercepted in
-the WebView and completes that same transaction. The same WebView session also
-supplies the web cookies and CSRF token for website-only adapters, so there is
-no second login.
+应用只有一个用户身份：OAuth，用于首页、收藏、关注、画廊、下载以及其他一切官方 API。未登录是引导状态，不是信息流错误。每次可见的尝试都独占一个 OAuth/PKCE 事务，并在应用内嵌 WebView 中打开官方登录页（使用桌面 User-Agent）。账号选择、密码、注册、社交登录与安全校验都由 DeviantArt 的页面负责。`dakit://oauth/callback` 在 WebView 内被拦截并完成同一事务。同一 WebView 会话同时提供仅网页适配器所需的 Cookie 与 CSRF token，因此不需要第二次登录。
 
-The WebView's web session (cookies and CSRF) is infrastructure state, not
-authentication. It must never block Home or display a login prompt, and its
-failure degrades to an official-API fallback or retry.
+WebView 的网页会话（Cookie 与 CSRF）属于基础设施状态，不是认证。它绝不能阻塞首页或弹出登录提示；失败时降级为官方 API 回退或重试。
 
-Session restoration reads only the current secure item (`DAViewer Account`).
-Ad-hoc Keychain items from previews before 0.2.139 are never queried or
-auto-migrated, so an inaccessible legacy record cannot request the Mac password
-or block authorization. Temporary network, upstream, parsing, or secure-storage
-failures preserve an established route; only missing/revoked credentials or
-explicit logout enter signed-out state.
-Hidden browser refreshes may rotate anonymous CSRF. A partial page is never
-proof of logout, and a legacy cookie username that mismatches OAuth is cleared.
+会话恢复只读取当前的安全项（`DAViewer Account`）。0.2.139 之前预览版产生的临时 Keychain 项永不查询、也不自动迁移，因此无法访问的历史记录不会索要 Mac 密码或阻塞授权。临时的网络、上游、解析或安全存储失败都保留既有可用路由；只有凭据缺失/被吊销或用户显式登出，才进入未登录状态。隐藏的浏览器刷新可能轮换匿名 CSRF。页面不完整永远不等于已登出；与 OAuth 账号不一致的历史 Cookie 用户名会被清除。
 
-Settings, proxy, diagnostics, updates, and About are public recovery routes and
-must stay reachable from the login screen.
+设置、代理、诊断、更新与关于属于公开的恢复路径，必须在登录页也可达。
 
-## Release contract
+## 发布契约
 
-- `pubspec.yaml` is the only source version edited by the release workflow.
-  Flutter exposes it to the app as `FLUTTER_BUILD_NAME`.
-- Every tag must have a matching top-level section in `RELEASE_NOTES.md`; CI uses
-  that section as the GitHub Release body.
-- CI analyzes, checks formatting, tests, and builds Android, macOS, and Windows.
-- Android releases require the configured upload keystore. macOS artifacts use
-  a private stable self-signed preview identity for Keychain continuity, but
-  remain non-Apple-signed and unnotarized; they keep the
-  `macos-unsigned-preview` marker until Developer ID signing and notarization.
-- Publishing keeps only the newest GitHub Release visible. Git tags remain as
-  the source-history record and are not deleted by the release job.
+- `pubspec.yaml` 是发布流程唯一编辑的版本来源。Flutter 通过 `FLUTTER_BUILD_NAME` 暴露给应用。
+- 每个 tag 必须在 `RELEASE_NOTES.md` 中有对应的顶层章节；CI 用该章节作为 GitHub Release 正文。
+- CI 执行 analyze、格式检查、测试，并构建 Android、macOS 与 Windows。
+- Android 发版需要已配置的上传密钥库。macOS 产物使用私有稳定的自签名预览身份以保持 Keychain 连续性，但仍不是 Apple 签名、也未公证；在具备 Developer ID 签名与公证之前，保留 `macos-unsigned-preview` 标记。
+- 发布只保留最新的 GitHub Release 可见。Git tag 作为源码历史记录保留，发布任务不会删除它们。
 
-## App-local state
+## 应用本地状态
 
-Some state is deliberately kept client-side and never synced to DeviantArt:
+部分状态刻意只保留在客户端，永不同步到 DeviantArt：
 
-- **Notification read state** (`NotificationReadStore`): DeviantArt exposes no
-  public "mark read" endpoint, so the unread dot is a local overlay on top of
-  the server's `isNew` flag. It persists locally and does not pretend to sync.
-- **User preferences** (`core/settings/AppPreferences`): language, theme mode,
-  the optional manual proxy, OAuth session evidence, and the update-reminder
-  state (last check time, dismissed version) are stored in a small JSON file
-  under the application-support directory. They are restored before the first
-  frame so the app never flashes defaults.
-- **Search interests** (`core/search/InterestStore`): lightweight persisted
-  tag-view counts that drive the personalized "recommended tags" on the search
-  page across restarts.
-- **Web-session cookie snapshot** (`core/auth/WebSessionStore`): the signed-in
-  deviantart.com cookies are snapshotted alongside the CSRF/username state and
-  re-injected on a cold start when the platform WebView store lost them (e.g.
-  across an app update). This keeps the personalized `rfy` feed alive without
-  another sign-in; the snapshot is guarded to the current OAuth account and is
-  not a second identity.
-- **Theme mode** (`core/theme/ThemeModeController`): system / light / dark, fed
-  into the MaterialApp and persisted with the preferences above.
+- **通知已读状态**（`NotificationReadStore`）：DeviantArt 没有公开的「标记已读」接口，因此未读圆点是叠加在服务端 `isNew` 标记之上的本地状态。它只本地持久化，不假装同步。
+- **用户偏好**（`core/settings/AppPreferences`）：语言、主题模式、可选手动代理、OAuth 会话证据与更新提醒状态（上次检查时间、已忽略版本）存放在 application-support 目录下的一个小 JSON 文件中。它们在首帧之前完成恢复，避免应用闪现默认值。
+- **搜索兴趣**（`core/search/InterestStore`）：轻量的持久化标签浏览计数，用于跨重启驱动搜索页的个性化「推荐标签」。
+- **网页会话 Cookie 快照**（`core/auth/WebSessionStore`）：已登录的 deviantart.com Cookie 与 CSRF/用户名状态一起快照，并在冷启动时平台 WebView 存储丢失（例如跨界应用更新）后重新注入。这能在不重新登录的前提下维持个性化 `rfy` 信息流；快照被限定在当前 OAuth 账号，不构成第二个身份。
+- **主题模式**（`core/theme/ThemeModeController`）：跟随系统 / 浅色 / 深色，注入 MaterialApp 并与上述偏好一起持久化。
 
-These overlays must stay local: adding a "sync to server" behavior would cross
-into the official API boundary and belongs in DAKit, not in the app.
+这些叠加层必须保持本地：一旦加入「同步到服务器」的行为，就越过了官方 API 边界，应属 DAKit 而非应用。

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,164 +1,70 @@
-# Authentication and session recovery
+# 认证与会话恢复
 
-DAViewer has one user identity: the official DeviantArt OAuth session. The app
-never receives or stores a DeviantArt, Google, Apple, Facebook, or Mac password.
-Credentials and provider security checks stay on DeviantArt's official page,
-which the app shows inside its own embedded WebView.
+> English: [Authentication and session recovery](/en/authentication.md)
 
-## One-entry sign-in contract
+DAViewer 只有一个用户身份：官方 DeviantArt OAuth 会话。应用既不接收也不存储 DeviantArt、Google、Apple、Facebook 或 Mac 的密码。凭据与各服务商的安全校验都留在 DeviantArt 官方页面，应用只在自己的内嵌 WebView 中展示该页面。
 
-The app exposes one **Sign in or create an account** action, which opens the
-embedded login screen:
+## 单入口登录契约
 
-1. DAKit creates one OAuth/PKCE transaction.
-2. DAViewer loads the official login page in its embedded WebView with a desktop
-   User-Agent, because DeviantArt's mobile login page omits the Google and Apple
-   one-click buttons the desktop page offers.
-3. DeviantArt's page owns account sign-in, registration, password recovery, and
-   every provider it currently offers (DeviantArt, Google, Apple, Facebook).
-   There is no separate "social login" route in the app.
-4. `dakit://oauth/callback` is intercepted inside the WebView and completes the
-   same transaction. The WebView keeps its cookies and CSRF token, so this one
-   login also establishes the web session used by the personalized `rfy` feed
-   and the collection adapters. No second sign-in is requested.
+应用只暴露一个 **登录或创建账号** 操作，它打开内嵌登录界面：
 
-The app does not simulate a provider-button click, embed a password form, copy
-cookies out of a system browser, or inspect human-verification DOM. It does set
-a desktop User-Agent so the full desktop login page is served. Google, Apple, or
-Facebook may still show their own account or CAPTCHA checks inside the WebView;
-those are the providers' pages and are not bypassed by the app.
+1. DAKit 创建一个 OAuth/PKCE 事务。
+2. DAViewer 以内嵌 WebView 加载官方登录页，并使用桌面 User-Agent —— 因为 DeviantArt 的移动登录页不提供桌面页上的一键 Google/Apple 按钮。
+3. 账号登录、注册、找回密码以及当前提供的全部服务商（DeviantArt、Google、Apple、Facebook）都由 DeviantArt 页面负责。应用内没有单独的「社交登录」路径。
+4. `dakit://oauth/callback` 在 WebView 内被拦截并完成同一事务。WebView 保留其 Cookie 与 CSRF token，因此这一次登录同时建立了后续个性化 `rfy` 信息流与合集适配器所需的网页会话，不再要求第二次登录。
 
-## Session roles
+应用不模拟服务商按钮点击、不内嵌密码表单、不从系统浏览器拷贝 Cookie，也不探测人机验证的 DOM。它只设置桌面 User-Agent，以便返回完整的桌面登录页。Google、Apple、Facebook 仍可能在自己的页面内展示账号选择或 CAPTCHA 校验；那属于服务商页面，应用不去绕过。
 
-- **OAuth session** (secure storage) powers the official API: daily
-  deviations, search, artwork lookup, favourites, watch, and downloads.
-- **Web session** (the WebView's cookies plus the CSRF token and login state,
-  persisted locally and restored at startup) powers the website-only adapters:
-  the personalized `rfy/deviations` feed and collection contents. The signed-in
-  cookies are snapshotted into the app's own storage and re-injected on a cold
-  start when the platform WebView store lost them (e.g. across an app update),
-  so the personalized feed survives without another sign-in.
+## 会话角色
 
-One embedded login establishes both sessions. The WebView reports the web
-session (CSRF token and the `userinfo` cookie) only after the OAuth callback has
-navigated back to the DeviantArt home page, so the app never records a
-signed-out web session from the anonymous login page.
+- **OAuth 会话**（安全存储）驱动官方 API：每日作品、搜索、作品查询、收藏、关注与下载。
+- **网页会话**（WebView 的 Cookie 加 CSRF token 与登录态，本地持久化并在启动时恢复）驱动仅网页可用的适配器：个性化 `rfy/deviations` 信息流与合集内容。已登录 Cookie 会快照进应用自身存储，并在冷启动时平台 WebView 存储丢失（例如跨界应用更新）后重新注入，从而不必重新登录也能保住个性化信息流。
 
-The login screen **dismisses itself as soon as a signed-in web session is
-reported** — it does not wait for an OAuth state transition. This covers both a
-first-time login and the "OAuth already signed in, web session lost" case
-(which the cookie vault exists for): the user never has to hunt for a Done
-button, and re-establishing only the web session never asks for a second
-OAuth approval.
+一次内嵌登录同时建立两种会话。WebView 只在 OAuth 回调回到 DeviantArt 首页之后才上报网页会话（CSRF token 与 `userinfo` Cookie），因此应用不会把匿名登录页的未登录状态记录为网页会话。
 
-While waiting, the user can cancel and reopen. Cancelling or starting a new
-attempt clears the pending transaction so a stale callback cannot absorb a later
-login. Settings, proxy, diagnostics, updates, About, language, and appearance
-remain reachable before sign-in.
+**一旦上报了已登录的网页会话，登录界面立即自行关闭**——它不等 OAuth 状态迁移。这同时覆盖首次登录与「OAuth 已登录但网页会话丢失」两种情况（Cookie 保险库正是为此存在）：用户不必寻找「完成」按钮，且仅重建网页会话时不会再次索要 OAuth 授权。
 
-The in-memory PKCE transaction is authoritative while the app process remains
-alive. Its secure-storage copy exists only to recover a callback after a process
-restart: failure to write, read, or clear that recovery copy must never overturn
-the live authorization result. Token storage is different and remains the hard
-commit point—sign-in is reported as successful only after the new token is
-stored securely.
+等待期间用户可以取消并重新打开。取消或开启新尝试都会清除待处理事务，避免过期回调吞掉后续登录。设置、代理、诊断、更新、关于、语言与外观在登录前均可达。
 
-The `dakit` scheme is owned by the embedded WebView, which intercepts the OAuth
-callback and never leaves the app. A system browser is used only as a fallback
-when no WebView listener is registered, and for the "content settings" link to
-DeviantArt's browsing preferences.
+只要应用进程存活，内存中的 PKCE 事务就是权威。它的安全存储副本只用于进程重启后恢复回调：写入、读取或清除该恢复副本失败，绝不能推翻仍在进行的授权结果。token 存储不同，它才是硬提交点——只有新 token 已安全存储，登录才被判定成功。
 
-## Cold-start contract
+`dakit` scheme 由内嵌 WebView 持有，它拦截 OAuth 回调且从不离开应用。只有在没有注册 WebView 监听器作为回退时，以及「内容设置」跳转 DeviantArt 浏览偏好时，才使用系统浏览器。
 
-1. With no cold-start OAuth callback, skip pending-transaction storage and read
-   only the current OAuth token.
-2. Treat only missing or revoked credentials as signed out. Temporary network,
-   upstream, timeout, parsing, and Keychain-availability failures preserve an
-   established session.
-3. Record non-sensitive session evidence only after secure storage has
-   successfully read or written tokens. This prevents a first-run network error
-   from routing an anonymous user into Home while preserving offline recovery
-   for existing users.
-4. Explicit logout clears the current OAuth store, session evidence, and the
-   WebView cookies.
+## 冷启动契约
 
-macOS previews use one private, stable CI signing identity. The identity is
-self-signed, not Apple trusted or notarized, but it prevents a changing ad-hoc
-cdhash from requesting the Mac password after each update. Token and recovery
-storage use the `DAViewer Account` Keychain service; older ad-hoc items are
-never queried, so an inaccessible legacy record cannot block authorization.
+1. 没有冷启动 OAuth 回调时，跳过待处理事务存储，只读取当前 OAuth token。
+2. 只有凭据缺失或被吊销才判定为未登录。临时性的网络、上游、超时、解析与 Keychain 不可用故障都保留既有会话。
+3. 只有在安全存储成功读写 token 之后，才记录非敏感的会话证据。这能避免首次运行的网络错误把匿名用户送进首页，同时保住老用户的离线恢复能力。
+4. 显式登出会清除当前 OAuth 存储、会话证据与 WebView Cookie。
 
-The Home **推荐 / For you** tab is the website's personalized `rfy/deviations`
-feed, fetched with the WebView's Cookie and CSRF token. It requires a signed-in
-web session; when the web session is absent the tab shows the sign-in prompt.
-The **每日精选 / Daily** tab uses the official OAuth API and does not depend on
-the web session. The product must not label these two sources as equivalent.
+macOS 预览版使用同一个私有稳定的 CI 签名身份。该身份是自签名的，不被 Apple 信任也未公证，但它能避免每次更新后变化的 ad-hoc cdhash 索要 Mac 密码。token 与恢复存储使用 `DAViewer Account` Keychain 服务；更早的 ad-hoc 项永不查询，因此无法访问的历史记录不会阻塞授权。
 
-## Public website adapters
+首页 **推荐 / For you** 标签是网站的个性化 `rfy/deviations` 信息流，使用 WebView 的 Cookie 与 CSRF token 拉取。它需要已登录的网页会话；网页会话缺失时该标签展示登录提示。**每日精选 / Daily** 标签使用官方 OAuth API，不依赖网页会话。产品上不得把这两个数据源表述为等价。
 
-A few detail-page features require undocumented public website data, such as
-numeric-id resolution and collection contents. The embedded WebView's web
-session (cookies and CSRF token) provides this on demand. This is infrastructure
-state, not a second user identity: it never blocks Home, never asks the user to
-log in again, and must degrade to a retry or official-API fallback when
-unavailable.
+## 公开网页适配器
 
-Legacy browser cookies are accepted only for public adapter compatibility. If
-they expose a username different from the OAuth account, they are cleared to
-prevent mixed-account data.
+少数详情页功能需要未公开的公开网页数据，例如数字 id 解析与合集内容。内嵌 WebView 的网页会话（Cookie 与 CSRF token）按需提供这些能力。它属于基础设施状态，不是第二个用户身份：绝不阻塞首页、绝不要求用户再次登录，不可用时必须降级为重试或官方 API 回退。
 
-## Cookie viewing, export, and import
+历史浏览器 Cookie 仅为兼容公开适配器而接受。若它们暴露的用户名与 OAuth 账号不同，会被清除，以防混账号数据。
 
-Settings → **账号 Cookie / Account cookies** shows the live deviantart.com
-web-session cookies as indented JSON and can copy them to the clipboard, so the
-user can view or back up their web session. The live WebView cookies are
-preferred; the persisted snapshot is used as a fallback when the WebView store
-cannot be read. The dialog carries an explicit warning that these cookies are
-login credentials. Export is a manual, user-initiated copy: nothing is sent
-anywhere by the app, and diagnostics/report output never includes cookies.
+## Cookie 查看、导出与导入
 
-The same dialog imports pasted cookies: exported JSON, a browser-extension
-cookie array (non-DeviantArt domains are ignored), or a `name=value; …` Cookie
-header. Import is the most identity-sensitive write in the app and follows a
-strict one-account rule (`evaluateCookieImportIdentity`):
+设置 → **账号 Cookie** 以缩进 JSON 展示当前的 deviantart.com 网页会话 Cookie，并可复制到剪贴板，便于用户查看或备份网页会话。优先使用 WebView 的实时 Cookie；WebView 存储不可读时回退到已持久化的快照。该对话框明确警告这些 Cookie 等同于登录凭据。导出是用户主动的手动复制：应用不会把任何内容发送到别处，诊断/报告输出也从不包含 Cookie。
 
-1. The imported cookies must carry a signed-in `userinfo` username; an
-   anonymous paste is rejected.
-2. If an OAuth account is signed in, the imported username must match it.
-3. If the live WebView already has a signed-in web session, the imported
-   username must match it.
-4. A conflict is rejected **before any cookie is written** — the app never
-   overlays one account's session onto another. To switch accounts the user
-   signs out first.
-5. After injection the username is read back from the cookie store. If
-   DeviantArt does not recognize the claimed session (expired/invalid
-   cookies), the previous cookies are restored and nothing is persisted.
+同一对话框也支持粘贴导入：导出的 JSON、浏览器扩展 Cookie 数组（非 DeviantArt 域名会被忽略），或 `name=value; …` 形式的 Cookie 头。导入是应用中最敏感的写入操作，遵循严格的一账号规则（`evaluateCookieImportIdentity`）：
 
-On a verified import the snapshot is persisted, the web-session state is
-updated, and a CSRF refresh runs so website adapters use the new session. An
-imported web-only session (no OAuth account) powers the web adapters and the
-personalized feed, while official-API features still require OAuth sign-in.
-After such an import the app therefore offers the normal embedded sign-in
-once: the DeviantArt page recognizes the imported cookies and typically
-completes without asking for a password, and the user can dismiss the prompt
-(web features keep working; official-API features ask for sign-in again on
-use). Cookies never replace the OAuth token — the official-API session can
-only be established by the OAuth/PKCE flow.
+1. 导入的 Cookie 必须带有已登录的 `userinfo` 用户名；匿名粘贴会被拒绝。
+2. 若已登录 OAuth 账号，导入的用户名必须与之一致。
+3. 若 WebView 已有已登录网页会话，导入的用户名必须与之一致。
+4. 冲突会在**写入任何 Cookie 之前**被拒绝——应用绝不把一个账号的会话叠加到另一个账号上。要切换账号需先登出。
+5. 注入完成后会从 Cookie 存储回读用户名。若 DeviantArt 不认可所声称的会话（Cookie 过期/无效），则恢复原有 Cookie，不持久化任何内容。
 
-## Mature content
+导入校验通过后，快照会被持久化、网页会话状态被更新，并触发一次 CSRF 刷新，使网页适配器使用新会话。仅网页的导入会话（无 OAuth 账号）可驱动网页适配器与个性化信息流，但官方 API 功能仍需 OAuth 登录。因此导入之后，应用会再提供一次常规内嵌登录：DeviantArt 页面会识别导入的 Cookie，通常无需输入密码即可完成，用户也可以关闭该提示（网页功能继续可用；官方 API 功能在使用时再次要求登录）。Cookie 永不替代 OAuth token —— 官方 API 会话只能通过 OAuth/PKCE 流程建立。
 
-`mature_content: true` is only a request flag. DeviantArt account browsing
-preferences remain authoritative and may hide or blur adult content. Settings
-links directly to DeviantArt's browsing preferences; the app does not bypass
-account restrictions.
+## 成人内容
 
-## User-facing error policy
+`mature_content: true` 只是一个请求标记。DeviantArt 的账号浏览偏好仍具权威性，可能隐藏或模糊成人内容。设置中直接链接到 DeviantArt 的浏览偏好；应用不绕过账号限制。
 
-Raw endpoint names, parser errors, HTTP payloads, package identifiers, and
-provider internals belong in Diagnostics. User UI states what failed and the
-next useful action. Authentication errors offer retry, reopen, cancel, proxy,
-and settings paths without claiming that a provider challenge is an App network
-failure. Secure-storage errors are never displayed as the raw phrase “Unable to
-access”; token-storage failures are distinguished from recovery-record cleanup
-warnings so the user is not told that a completed authorization was a network or
-account failure.
+## 面向用户的错误策略
+
+原始端点名、解析器错误、HTTP 负载、包标识与服务商内部信息属于「诊断」。用户界面只说明失败原因与下一步可用操作。认证错误提供重试、重新打开、取消、代理与设置路径，但不会把服务商的挑战页面说成「应用网络故障」。安全存储错误绝不显示为原始的 “Unable to access”；token 存储失败与恢复记录清理告警会被区分开，避免把已完成的授权误报为网络或账号故障。

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,78 +1,58 @@
-# DAViewer build notes
+# DAViewer 构建说明
 
-Toolchain, release, and build-proxy details that are too deep for the README.
+> English: [DAViewer build notes](/en/build.md)
 
-## Toolchain pin
+README 放不下、又不适合省略的工具链、发版与构建代理细节。
 
-Flutter 3.47 defaults to AGP 9.1.0, but the stable `flutter_inappwebview` (6.1.5)
-Android sub-package still references `proguard-android.txt`, which AGP 9 removed,
-and its beta macOS sub-package fails to compile under Swift 6. This project
-therefore pins the following toolchain (meeting Flutter 3.47's Gradle ≥ 8.14 /
-Kotlin ≥ 2.2.20 minimums):
+## 工具链版本固定
 
-| Component | Version | Notes |
+Flutter 3.47 默认使用 AGP 9.1.0，但稳定版 `flutter_inappwebview`（6.1.5）的 Android 子包仍引用 `proguard-android.txt`（AGP 9 已移除该文件），其 beta 版 macOS 子包在 Swift 6 下也无法编译。因此本项目固定以下工具链（均满足 Flutter 3.47 的 Gradle ≥ 8.14 / Kotlin ≥ 2.2.20 下限）：
+
+| 组件 | 版本 | 说明 |
 | --- | --- | --- |
-| Android Gradle Plugin | `8.13.2` | 8.x keeps `proguard-android.txt` and supports compileSdk 36 |
-| Gradle | `8.14.2` | Flutter 3.47 minimum is 8.14 |
-| Kotlin | `2.2.20` | Flutter 3.47 minimum is 2.2.20 |
-| flutter_inappwebview | `6.1.5` (exact) | Stable; do not upgrade to `6.2.0-beta` (macOS build fails) |
+| Android Gradle Plugin | `8.13.2` | 8.x 保留 `proguard-android.txt`，且支持 compileSdk 36 |
+| Gradle | `8.14.2` | Flutter 3.47 下限为 8.14 |
+| Kotlin | `2.2.20` | Flutter 3.47 下限为 2.2.20 |
+| flutter_inappwebview | `6.1.5`（精确） | 稳定版；不要升到 `6.2.0-beta`（macOS 构建失败） |
 
-These values live in `android/settings.gradle.kts`,
-`android/gradle/wrapper/gradle-wrapper.properties`, and `pubspec.yaml`. Before
-upgrading the plugin or Flutter, verify the `flutter_inappwebview` Android/macOS
-sub-packages are compatible with the new AGP/Swift toolchain.
+这些值位于 `android/settings.gradle.kts`、`android/gradle/wrapper/gradle-wrapper.properties` 与 `pubspec.yaml`。升级插件或 Flutter 之前，请先确认 `flutter_inappwebview` 的 Android/macOS 子包与新 AGP/Swift 工具链兼容。
 
-## Release contract
+## 发布契约
 
-- Pushes to `main` trigger CI quality checks and Android/macOS/Windows builds;
-  pushing a `v*` tag creates a GitHub Release whose notes come from the matching
-  user-facing `RELEASE_NOTES.md` section. A missing section blocks the release
-  instead of exposing commit messages or internal implementation notes.
-- The release APK is always signed with the upload keystore (CI
-  `KEYSTORE_B64` / `KEYSTORE_PROPERTIES` secrets); a release build without a
-  local `android/key.properties` fails intentionally, so a debug-signed APK can
-  never be installed over a previous upload-signed release.
-- macOS release tags require the private preview certificate secrets. CI signs
-  with that stable self-signed identity, reapplies the checked-in entitlements,
-  verifies both CPU architectures, and keeps the app running for an eight-second
-  launch smoke test. Non-release builds may fall back to ad-hoc signing.
-  Artifacts remain `macos-unsigned-preview` because the preview identity is not
-  an Apple Developer ID and the package is not notarized.
+- 推送到 `main` 触发 CI 质量检查与 Android/macOS/Windows 构建；推送 `v*` tag 会创建 GitHub Release，其说明取自 `RELEASE_NOTES.md` 中对应的面向用户章节。缺少该章节会**阻止**发版，而不是退化成提交信息或内部实现说明。
+- 发布用 APK 始终使用上传密钥库签名（CI 机密 `KEYSTORE_B64` / `KEYSTORE_PROPERTIES`）；缺少本地 `android/key.properties` 的 release 构建会**故意失败**，从而不可能用 debug 签名的 APK 覆盖此前上传签名的发布版。
+- macOS 发布 tag 需要私有预览证书机密。CI 用该稳定自签名身份签名、重新应用仓库内声明的 entitlements、校验两种 CPU 架构，并让应用保持运行 8 秒完成启动冒烟测试。非发布构建可回退到 ad-hoc 签名。产物仍带 `macos-unsigned-preview` 标记，因为预览身份不是 Apple Developer ID，包也未公证。
 
-### One-click release
+### 一键发版
 
-Actions → **Release** → Run workflow → pick `patch` / `minor` / `major` (or an
-exact version) → run. It bumps the version, commits, pushes the tag, and CI
-builds and publishes.
+Actions → **Release** → Run workflow → 选择 `patch` / `minor` / `major`（或具体版本）→ 运行。它会升版本、提交、推 tag，CI 随后构建并发布。
 
-Local verification builds:
+本地验证构建：
 
 ```shell
-flutter build apk --release          # Android APK (requires android/key.properties)
-flutter build macos --release        # macOS app
-flutter build windows --release      # Windows app
+flutter build apk --release          # Android APK（需要 android/key.properties）
+flutter build macos --release        # macOS 应用
+flutter build windows --release      # Windows 应用
 ```
 
-## Proxying builds
+## 构建走代理
 
-`flutter pub get` uses Dart's HTTP client, not the Git proxy:
+`flutter pub get` 使用 Dart 的 HTTP 客户端，不读 Git 代理配置：
 
 ```shell
 export http_proxy=http://127.0.0.1:7890
 export https_proxy=http://127.0.0.1:7890
-# Or one general proxy (lowercase and uppercase variables are supported):
-# 7892 is only an example; replace it with your proxy's HTTP/Mixed port.
+# 或使用一个通用代理（大小写变量都受支持）：
+# 7892 只是示例，请替换成你自己代理的 HTTP/Mixed 端口。
 # export all_proxy=http://127.0.0.1:7892
 export no_proxy=localhost,127.0.0.1
 flutter pub get
 ```
 
-The Gradle Wrapper runs on the JVM and is not guaranteed to read `all_proxy`.
-Pass JVM proxy properties explicitly when an Android toolchain download needs a
-proxy:
+Gradle Wrapper 运行在 JVM 上，不保证读取 `all_proxy`。当 Android 工具链下载需要代理时，显式传入 JVM 代理属性：
 
 ```shell
-# Replace 7892 with the actual HTTP/Mixed port shown by your proxy app.
+# 把 7892 替换成代理应用实际显示的 HTTP/Mixed 端口。
 export GRADLE_OPTS="-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=7892 -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=7892"
 flutter build apk --debug
 ```

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,10 +1,12 @@
 # 📥 下载 DAViewer
 
+**语言 / Language:** 中文 · [English](/en/download.md)
+
 本页由 GitHub Actions 在每次发版时**自动更新**，始终指向最新 Release。
 
-## 最新版本：`v0.2.182`（2026-09-05）
+## 最新版本：`v0.2.184`（2026-09-06）
 
-👉 [查看 Release 说明与校验和](https://github.com/redtidev1918/daviewer/releases/tag/v0.2.182)
+👉 [查看 Release 说明与校验和](https://github.com/redtidev1918/daviewer/releases/tag/v0.2.184)
 
 ### 📱 App 预览
 
@@ -18,6 +20,11 @@
 
 | 平台 | 文件 | 大小 | 下载 |
 |---|---|---|---|
-| Android | `DAViewer-0.2.182.apk` | 62.3 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.182/DAViewer-0.2.182.apk) |
-| Windows | `DAViewer-0.2.182-windows.zip` | 13.9 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.182/DAViewer-0.2.182-windows.zip) |
-| macOS | `DAViewer-0.2.182-macos-unsigned-preview.zip` | 23.6 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.182/DAViewer-0.2.182-macos-unsigned-preview.zip) |
+| Android | `DAViewer-0.2.184.apk` | 62.4 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-0.2.184.apk) |
+| Android | `DAViewer-v0.2.184.apk` | 62.4 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-v0.2.184.apk) |
+| Windows | `DAViewer-0.2.184-windows.zip` | 13.9 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-0.2.184-windows.zip) |
+| Windows | `DAViewer-v0.2.184-windows.zip` | 13.9 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-v0.2.184-windows.zip) |
+| macOS | `DAViewer-0.2.184-macos-unsigned-preview.zip` | 23.7 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-0.2.184-macos-unsigned-preview.zip) |
+| macOS | `DAViewer-v0.2.184-macos-unsigned-preview.zip` | 23.7 MB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-v0.2.184-macos-unsigned-preview.zip) |
+| 通用 | `RELEASE-METADATA.json` | 2 KB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/RELEASE-METADATA.json) |
+| 通用 | `SHA256SUMS` | 1 KB | [⬇️ 下载](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/SHA256SUMS) |

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,0 +1,33 @@
+# DAViewer Documentation
+
+**Language / 语言:** [中文](/) · English
+
+> DAViewer is an open-source DeviantArt client built on
+> [DAKit](https://github.com/redtidev1918/dakit), targeting Android, macOS and Windows.
+> This English section mirrors the developer documentation page-by-page with the Chinese
+> section under `/`.
+
+## Entry points
+
+| Document | Content |
+| :-- | :-- |
+| [📥 Download](download.md) | Android / Windows / macOS packages, auto-updated on every release |
+| [README (English)](https://github.com/redtidev1918/daviewer/blob/main/README.en.md) | User-facing overview and install |
+
+## Developer documentation
+
+| English (here) | 中文 |
+| :-- | :-- |
+| [Architecture](architecture.md) | [架构说明](/architecture.md) |
+| [Web adapter — compatibility contract](web_adapter.md) | [网页适配器 —— 兼容性契约](/web_adapter.md) |
+| [Authentication and session recovery](authentication.md) | [认证与会话恢复](/authentication.md) |
+| [Networking and proxy](networking.md) | [网络与代理](/networking.md) |
+| [Build notes](build.md) | [构建说明](/build.md) |
+
+## Links
+
+- Repository: <https://github.com/redtidev1918/daviewer>
+- Releases: <https://github.com/redtidev1918/daviewer/releases>
+- Upstream SDK documentation: <https://github.com/redtidev1918/dakit>
+- Changelog: <https://github.com/redtidev1918/daviewer/blob/main/CHANGELOG.md>
+- Release notes: <https://github.com/redtidev1918/daviewer/blob/main/RELEASE_NOTES.md>

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -1,0 +1,213 @@
+# DAViewer architecture
+
+**Language / 语言:** [中文](/architecture.md) · English
+
+This document defines the boundaries that are easiest to blur when fixing feed,
+detail, authentication, media, and release bugs.
+
+## SDK and app boundary
+
+- **DAKit** owns OAuth, official DeviantArt API transports and DTO mapping,
+  domain models, secure token storage, and background transfers.
+- **DAViewer** owns web-session endpoints that have no official equivalent,
+  source fallback policy, native navigation and gestures, UI state, and
+  host-level caching.
+- Web responses are mapped into DAKit domain models before entering feature
+  code. Features must not maintain a second artwork model.
+
+Before adding an app workaround, verify whether the official response was
+mapped incorrectly. Fix mapping and transport contracts in DAKit; fix source
+composition, sparse-data hydration, caching, and presentation in DAViewer.
+
+## Artwork data flow
+
+```text
+official/web list source
+        ↓ (possibly sparse Artwork)
+ArtworkStore.putAll
+        ↓
+feed card → detail route → artworkDetailProvider
+                            ↓ missing detail-only field
+                  deviation/metadata adapter
+                            ↓
+                    ArtworkStore.setTags
+```
+
+List endpoints may legally omit fields such as tags, and `deviation/{id}` does
+not reliably add them back. An empty list therefore does not prove that a work
+is tagless until the dedicated `deviation/metadata` endpoint confirms it.
+`ArtworkStore` records that resolution separately, including a confirmed empty
+result, and preserves hydrated tags when a later feed refresh contains a sparse
+object.
+
+Rules:
+
+1. Do not make every feed eagerly fetch every detail; hydrate only the field the
+   visible screen needs.
+2. Do not replace a rich cached object with a sparse list object without a merge
+   rule.
+3. Cache a confirmed empty result so genuinely tagless works do not refetch on
+   every visit.
+4. A hydration failure may hide that optional section, but must not make the
+   artwork detail page unusable.
+
+### Preview-card presentation
+
+All artwork feeds use the shared `ArtworkCard` and the preview-aspect helper.
+The card is a column: the image keeps its natural aspect ratio (extreme
+landscape media is capped at 1.6:1 on phone-width viewports, 2:1 on desktop,
+with `BoxFit.cover` cropping the outer edges so the subject stays useful at
+thumbnail size), and the title/author render **below** the image as a normal
+card section — never as an overlay on top of the artwork. New feed surfaces
+must reuse the card instead of restoring a fixed-height overlay. The GIF /
+multi-image badges remain positioned on the image itself.
+
+## Related-content state
+
+Website recommendation data has two supported server-rendered shapes: the
+current streamed `window.__RCACHE__.relatedContent` payload and the legacy
+normalized `window.__INITIAL_STATE__` metadata/entities. The streamed cache is
+preferred when complete, then parsing falls back to the legacy state. A missing
+`currentBiMetadata` entry or missing normalized entities is inconclusive, not a
+confirmed empty recommendation set. An empty success is shown only when the
+website parse and official fallback both finish without errors.
+
+Related **artwork** comes from the website source when available (it can diverge
+from the legacy preview) and falls back to the official `browse/morelikethis`
+preview. Featured/suggested **collections** exist only in the official preview,
+so `moreLikeThisProvider` always fetches the official result and merges it with
+the website artwork (`mergeMoreLikeThisResult`); the collection rails therefore
+show consistently instead of disappearing whenever the website source happens
+to return artwork.
+
+Refreshing related content is one awaited operation. Existing cards remain
+visible during it, and completion must report one of three outcomes: changed,
+unchanged, or still empty. Source failures retain their network, session,
+service, or page-format classification instead of being masked by an empty
+fallback.
+
+Provider/parser names and raw exception messages are diagnostic data. User copy
+describes only the outcome and next action (checking, updated, unchanged, no
+result, sign in, check network, or try later).
+
+## Collection contents and artist discovery
+
+**Collection full contents** (`WebCollectionContentsFetcher`): the official API
+only accepts a UUID `folderid`, while the preview exposes a numeric id, so there
+is no official full-contents path. DAViewer reads the website's own
+`_puppy/dashared/gallection/contents` JSON endpoint when a web session (Cookie +
+CSRF) is available, falling back to the server-rendered page
+(`deviantart.com/{username}/favourites/{folderId}?page=N`, which is public and
+needs no session) otherwise. Both carry the same deviation shape, so the mapping
+reuses `WebDeviationMapper.mapDeviation`. The UI shows the preview deviations
+instantly and swaps in the full list when ready, with an "open on the web"
+fallback.
+
+**Collection covers**: the "More Like This" preview only sometimes carries a
+collection thumbnail. When it does not, the collection card lazily resolves the
+cover from `gallection/contents` (`collectionCoverProvider`), so cards do not
+stay blank; the folder-icon placeholder is only the last resort.
+
+**Watching a collection is not implemented.** The official API can watch a
+*user* (`user/watch`), not a specific collection/folder; a collection watch
+exists only in an undocumented web surface. Until that is reverse-engineered
+(web-session work, out of DAKit), collection cards open the collection natively
+but offer no follow action.
+
+**More from this artist** (`MoreFromArtistSection`): the author's other recent
+works, read from the official `gallery/{username}` first page. This is the
+cleanly available "artist discovery" path.
+
+**Similar artists** (`SimilarArtistsSection`): DeviantArt has no public
+similar-artists endpoint — the official API only offers `browse/morelikethis`
+(deviations + collections), and the website's `biMetadata` `type: "artist"` hint
+is BI tracking (the author's account type), not a recommendation payload. The
+real "similar deviants" list streams post-hydration from an undocumented
+endpoint (absent from `__INITIAL_STATE__`, `__RCACHE__`, and `dadeviation/init`).
+DAViewer therefore derives similar artists from the "More Like This" artwork
+authors (`similarArtistsFrom`): artists whose work the recommendation engine
+surfaced as related are the honest equivalent. A future dedicated source would
+be a web-session reverse-engineering effort and must stay out of DAKit.
+
+## Gesture ownership
+
+Artwork browsing and image panning share horizontal movement, so ownership is
+state-dependent:
+
+- At 1x zoom, the outer viewer may recognize a horizontal artwork-navigation
+  gesture.
+- Above 1x zoom, every outer horizontal callback must be `null`; even a lone
+  cancel callback registers a competing recognizer and can steal mobile pans.
+- Multi-image paging consumes movement first. Artwork navigation begins only
+  after a further edge swipe at the first or last internal page.
+- Gesture tests must assert both the intended movement and the absence of an
+  unintended artwork-navigation callback.
+
+## Authentication boundary
+
+The app has one user identity: OAuth for Home, favourites, watch, galleries,
+downloads, and every other official API. Signed-out state is onboarding, not a
+feed error. Each visible attempt owns one OAuth/PKCE transaction and opens the
+official login page in the app's embedded WebView (with a desktop User-Agent).
+DeviantArt's page owns account selection, passwords, registration, social
+providers, and security checks. The `dakit://oauth/callback` is intercepted in
+the WebView and completes that same transaction. The same WebView session also
+supplies the web cookies and CSRF token for website-only adapters, so there is
+no second login.
+
+The WebView's web session (cookies and CSRF) is infrastructure state, not
+authentication. It must never block Home or display a login prompt, and its
+failure degrades to an official-API fallback or retry.
+
+Session restoration reads only the current secure item (`DAViewer Account`).
+Ad-hoc Keychain items from previews before 0.2.139 are never queried or
+auto-migrated, so an inaccessible legacy record cannot request the Mac password
+or block authorization. Temporary network, upstream, parsing, or secure-storage
+failures preserve an established route; only missing/revoked credentials or
+explicit logout enter signed-out state.
+Hidden browser refreshes may rotate anonymous CSRF. A partial page is never
+proof of logout, and a legacy cookie username that mismatches OAuth is cleared.
+
+Settings, proxy, diagnostics, updates, and About are public recovery routes and
+must stay reachable from the login screen.
+
+## Release contract
+
+- `pubspec.yaml` is the only source version edited by the release workflow.
+  Flutter exposes it to the app as `FLUTTER_BUILD_NAME`.
+- Every tag must have a matching top-level section in `RELEASE_NOTES.md`; CI uses
+  that section as the GitHub Release body.
+- CI analyzes, checks formatting, tests, and builds Android, macOS, and Windows.
+- Android releases require the configured upload keystore. macOS artifacts use
+  a private stable self-signed preview identity for Keychain continuity, but
+  remain non-Apple-signed and unnotarized; they keep the
+  `macos-unsigned-preview` marker until Developer ID signing and notarization.
+- Publishing keeps only the newest GitHub Release visible. Git tags remain as
+  the source-history record and are not deleted by the release job.
+
+## App-local state
+
+Some state is deliberately kept client-side and never synced to DeviantArt:
+
+- **Notification read state** (`NotificationReadStore`): DeviantArt exposes no
+  public "mark read" endpoint, so the unread dot is a local overlay on top of
+  the server's `isNew` flag. It persists locally and does not pretend to sync.
+- **User preferences** (`core/settings/AppPreferences`): language, theme mode,
+  the optional manual proxy, OAuth session evidence, and the update-reminder
+  state (last check time, dismissed version) are stored in a small JSON file
+  under the application-support directory. They are restored before the first
+  frame so the app never flashes defaults.
+- **Search interests** (`core/search/InterestStore`): lightweight persisted
+  tag-view counts that drive the personalized "recommended tags" on the search
+  page across restarts.
+- **Web-session cookie snapshot** (`core/auth/WebSessionStore`): the signed-in
+  deviantart.com cookies are snapshotted alongside the CSRF/username state and
+  re-injected on a cold start when the platform WebView store lost them (e.g.
+  across an app update). This keeps the personalized `rfy` feed alive without
+  another sign-in; the snapshot is guarded to the current OAuth account and is
+  not a second identity.
+- **Theme mode** (`core/theme/ThemeModeController`): system / light / dark, fed
+  into the MaterialApp and persisted with the preferences above.
+
+These overlays must stay local: adding a "sync to server" behavior would cross
+into the official API boundary and belongs in DAKit, not in the app.

--- a/docs/en/authentication.md
+++ b/docs/en/authentication.md
@@ -1,0 +1,166 @@
+# Authentication and session recovery
+
+**Language / 语言:** [中文](/authentication.md) · English
+
+DAViewer has one user identity: the official DeviantArt OAuth session. The app
+never receives or stores a DeviantArt, Google, Apple, Facebook, or Mac password.
+Credentials and provider security checks stay on DeviantArt's official page,
+which the app shows inside its own embedded WebView.
+
+## One-entry sign-in contract
+
+The app exposes one **Sign in or create an account** action, which opens the
+embedded login screen:
+
+1. DAKit creates one OAuth/PKCE transaction.
+2. DAViewer loads the official login page in its embedded WebView with a desktop
+   User-Agent, because DeviantArt's mobile login page omits the Google and Apple
+   one-click buttons the desktop page offers.
+3. DeviantArt's page owns account sign-in, registration, password recovery, and
+   every provider it currently offers (DeviantArt, Google, Apple, Facebook).
+   There is no separate "social login" route in the app.
+4. `dakit://oauth/callback` is intercepted inside the WebView and completes the
+   same transaction. The WebView keeps its cookies and CSRF token, so this one
+   login also establishes the web session used by the personalized `rfy` feed
+   and the collection adapters. No second sign-in is requested.
+
+The app does not simulate a provider-button click, embed a password form, copy
+cookies out of a system browser, or inspect human-verification DOM. It does set
+a desktop User-Agent so the full desktop login page is served. Google, Apple, or
+Facebook may still show their own account or CAPTCHA checks inside the WebView;
+those are the providers' pages and are not bypassed by the app.
+
+## Session roles
+
+- **OAuth session** (secure storage) powers the official API: daily
+  deviations, search, artwork lookup, favourites, watch, and downloads.
+- **Web session** (the WebView's cookies plus the CSRF token and login state,
+  persisted locally and restored at startup) powers the website-only adapters:
+  the personalized `rfy/deviations` feed and collection contents. The signed-in
+  cookies are snapshotted into the app's own storage and re-injected on a cold
+  start when the platform WebView store lost them (e.g. across an app update),
+  so the personalized feed survives without another sign-in.
+
+One embedded login establishes both sessions. The WebView reports the web
+session (CSRF token and the `userinfo` cookie) only after the OAuth callback has
+navigated back to the DeviantArt home page, so the app never records a
+signed-out web session from the anonymous login page.
+
+The login screen **dismisses itself as soon as a signed-in web session is
+reported** — it does not wait for an OAuth state transition. This covers both a
+first-time login and the "OAuth already signed in, web session lost" case
+(which the cookie vault exists for): the user never has to hunt for a Done
+button, and re-establishing only the web session never asks for a second
+OAuth approval.
+
+While waiting, the user can cancel and reopen. Cancelling or starting a new
+attempt clears the pending transaction so a stale callback cannot absorb a later
+login. Settings, proxy, diagnostics, updates, About, language, and appearance
+remain reachable before sign-in.
+
+The in-memory PKCE transaction is authoritative while the app process remains
+alive. Its secure-storage copy exists only to recover a callback after a process
+restart: failure to write, read, or clear that recovery copy must never overturn
+the live authorization result. Token storage is different and remains the hard
+commit point—sign-in is reported as successful only after the new token is
+stored securely.
+
+The `dakit` scheme is owned by the embedded WebView, which intercepts the OAuth
+callback and never leaves the app. A system browser is used only as a fallback
+when no WebView listener is registered, and for the "content settings" link to
+DeviantArt's browsing preferences.
+
+## Cold-start contract
+
+1. With no cold-start OAuth callback, skip pending-transaction storage and read
+   only the current OAuth token.
+2. Treat only missing or revoked credentials as signed out. Temporary network,
+   upstream, timeout, parsing, and Keychain-availability failures preserve an
+   established session.
+3. Record non-sensitive session evidence only after secure storage has
+   successfully read or written tokens. This prevents a first-run network error
+   from routing an anonymous user into Home while preserving offline recovery
+   for existing users.
+4. Explicit logout clears the current OAuth store, session evidence, and the
+   WebView cookies.
+
+macOS previews use one private, stable CI signing identity. The identity is
+self-signed, not Apple trusted or notarized, but it prevents a changing ad-hoc
+cdhash from requesting the Mac password after each update. Token and recovery
+storage use the `DAViewer Account` Keychain service; older ad-hoc items are
+never queried, so an inaccessible legacy record cannot block authorization.
+
+The Home **推荐 / For you** tab is the website's personalized `rfy/deviations`
+feed, fetched with the WebView's Cookie and CSRF token. It requires a signed-in
+web session; when the web session is absent the tab shows the sign-in prompt.
+The **每日精选 / Daily** tab uses the official OAuth API and does not depend on
+the web session. The product must not label these two sources as equivalent.
+
+## Public website adapters
+
+A few detail-page features require undocumented public website data, such as
+numeric-id resolution and collection contents. The embedded WebView's web
+session (cookies and CSRF token) provides this on demand. This is infrastructure
+state, not a second user identity: it never blocks Home, never asks the user to
+log in again, and must degrade to a retry or official-API fallback when
+unavailable.
+
+Legacy browser cookies are accepted only for public adapter compatibility. If
+they expose a username different from the OAuth account, they are cleared to
+prevent mixed-account data.
+
+## Cookie viewing, export, and import
+
+Settings → **账号 Cookie / Account cookies** shows the live deviantart.com
+web-session cookies as indented JSON and can copy them to the clipboard, so the
+user can view or back up their web session. The live WebView cookies are
+preferred; the persisted snapshot is used as a fallback when the WebView store
+cannot be read. The dialog carries an explicit warning that these cookies are
+login credentials. Export is a manual, user-initiated copy: nothing is sent
+anywhere by the app, and diagnostics/report output never includes cookies.
+
+The same dialog imports pasted cookies: exported JSON, a browser-extension
+cookie array (non-DeviantArt domains are ignored), or a `name=value; …` Cookie
+header. Import is the most identity-sensitive write in the app and follows a
+strict one-account rule (`evaluateCookieImportIdentity`):
+
+1. The imported cookies must carry a signed-in `userinfo` username; an
+   anonymous paste is rejected.
+2. If an OAuth account is signed in, the imported username must match it.
+3. If the live WebView already has a signed-in web session, the imported
+   username must match it.
+4. A conflict is rejected **before any cookie is written** — the app never
+   overlays one account's session onto another. To switch accounts the user
+   signs out first.
+5. After injection the username is read back from the cookie store. If
+   DeviantArt does not recognize the claimed session (expired/invalid
+   cookies), the previous cookies are restored and nothing is persisted.
+
+On a verified import the snapshot is persisted, the web-session state is
+updated, and a CSRF refresh runs so website adapters use the new session. An
+imported web-only session (no OAuth account) powers the web adapters and the
+personalized feed, while official-API features still require OAuth sign-in.
+After such an import the app therefore offers the normal embedded sign-in
+once: the DeviantArt page recognizes the imported cookies and typically
+completes without asking for a password, and the user can dismiss the prompt
+(web features keep working; official-API features ask for sign-in again on
+use). Cookies never replace the OAuth token — the official-API session can
+only be established by the OAuth/PKCE flow.
+
+## Mature content
+
+`mature_content: true` is only a request flag. DeviantArt account browsing
+preferences remain authoritative and may hide or blur adult content. Settings
+links directly to DeviantArt's browsing preferences; the app does not bypass
+account restrictions.
+
+## User-facing error policy
+
+Raw endpoint names, parser errors, HTTP payloads, package identifiers, and
+provider internals belong in Diagnostics. User UI states what failed and the
+next useful action. Authentication errors offer retry, reopen, cancel, proxy,
+and settings paths without claiming that a provider challenge is an App network
+failure. Secure-storage errors are never displayed as the raw phrase “Unable to
+access”; token-storage failures are distinguished from recovery-record cleanup
+warnings so the user is not told that a completed authorization was a network or
+account failure.

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -1,0 +1,80 @@
+# DAViewer build notes
+
+**Language / 语言:** [中文](/build.md) · English
+
+Toolchain, release, and build-proxy details that are too deep for the README.
+
+## Toolchain pin
+
+Flutter 3.47 defaults to AGP 9.1.0, but the stable `flutter_inappwebview` (6.1.5)
+Android sub-package still references `proguard-android.txt`, which AGP 9 removed,
+and its beta macOS sub-package fails to compile under Swift 6. This project
+therefore pins the following toolchain (meeting Flutter 3.47's Gradle ≥ 8.14 /
+Kotlin ≥ 2.2.20 minimums):
+
+| Component | Version | Notes |
+| --- | --- | --- |
+| Android Gradle Plugin | `8.13.2` | 8.x keeps `proguard-android.txt` and supports compileSdk 36 |
+| Gradle | `8.14.2` | Flutter 3.47 minimum is 8.14 |
+| Kotlin | `2.2.20` | Flutter 3.47 minimum is 2.2.20 |
+| flutter_inappwebview | `6.1.5` (exact) | Stable; do not upgrade to `6.2.0-beta` (macOS build fails) |
+
+These values live in `android/settings.gradle.kts`,
+`android/gradle/wrapper/gradle-wrapper.properties`, and `pubspec.yaml`. Before
+upgrading the plugin or Flutter, verify the `flutter_inappwebview` Android/macOS
+sub-packages are compatible with the new AGP/Swift toolchain.
+
+## Release contract
+
+- Pushes to `main` trigger CI quality checks and Android/macOS/Windows builds;
+  pushing a `v*` tag creates a GitHub Release whose notes come from the matching
+  user-facing `RELEASE_NOTES.md` section. A missing section blocks the release
+  instead of exposing commit messages or internal implementation notes.
+- The release APK is always signed with the upload keystore (CI
+  `KEYSTORE_B64` / `KEYSTORE_PROPERTIES` secrets); a release build without a
+  local `android/key.properties` fails intentionally, so a debug-signed APK can
+  never be installed over a previous upload-signed release.
+- macOS release tags require the private preview certificate secrets. CI signs
+  with that stable self-signed identity, reapplies the checked-in entitlements,
+  verifies both CPU architectures, and keeps the app running for an eight-second
+  launch smoke test. Non-release builds may fall back to ad-hoc signing.
+  Artifacts remain `macos-unsigned-preview` because the preview identity is not
+  an Apple Developer ID and the package is not notarized.
+
+### One-click release
+
+Actions → **Release** → Run workflow → pick `patch` / `minor` / `major` (or an
+exact version) → run. It bumps the version, commits, pushes the tag, and CI
+builds and publishes.
+
+Local verification builds:
+
+```shell
+flutter build apk --release          # Android APK (requires android/key.properties)
+flutter build macos --release        # macOS app
+flutter build windows --release      # Windows app
+```
+
+## Proxying builds
+
+`flutter pub get` uses Dart's HTTP client, not the Git proxy:
+
+```shell
+export http_proxy=http://127.0.0.1:7890
+export https_proxy=http://127.0.0.1:7890
+# Or one general proxy (lowercase and uppercase variables are supported):
+# 7892 is only an example; replace it with your proxy's HTTP/Mixed port.
+# export all_proxy=http://127.0.0.1:7892
+export no_proxy=localhost,127.0.0.1
+flutter pub get
+```
+
+The Gradle Wrapper runs on the JVM and is not guaranteed to read `all_proxy`.
+Pass JVM proxy properties explicitly when an Android toolchain download needs a
+proxy:
+
+```shell
+# Replace 7892 with the actual HTTP/Mixed port shown by your proxy app.
+export GRADLE_OPTS="-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=7892 -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=7892"
+flutter build apk --debug
+```

--- a/docs/en/download.md
+++ b/docs/en/download.md
@@ -1,0 +1,20 @@
+# 📥 Download DAViewer
+
+**Language / 语言:** [中文](/download.md) · English
+
+This page is **generated automatically** by GitHub Actions on every release and always points at the latest one.
+
+## Latest version: `v0.2.184` (2026-09-06)
+
+👉 [Release notes and checksums](https://github.com/redtidev1918/daviewer/releases/tag/v0.2.184)
+
+| Platform | File | Size | Download |
+|---|---|---|---|
+| Android | `DAViewer-0.2.184.apk` | 62.4 MB | [⬇️ Download](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-0.2.184.apk) |
+| Android | `DAViewer-v0.2.184.apk` | 62.4 MB | [⬇️ Download](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-v0.2.184.apk) |
+| Windows | `DAViewer-0.2.184-windows.zip` | 13.9 MB | [⬇️ Download](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-0.2.184-windows.zip) |
+| Windows | `DAViewer-v0.2.184-windows.zip` | 13.9 MB | [⬇️ Download](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-v0.2.184-windows.zip) |
+| macOS | `DAViewer-0.2.184-macos-unsigned-preview.zip` | 23.7 MB | [⬇️ Download](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-0.2.184-macos-unsigned-preview.zip) |
+| macOS | `DAViewer-v0.2.184-macos-unsigned-preview.zip` | 23.7 MB | [⬇️ Download](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/DAViewer-v0.2.184-macos-unsigned-preview.zip) |
+| All platforms | `RELEASE-METADATA.json` | 2 KB | [⬇️ Download](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/RELEASE-METADATA.json) |
+| All platforms | `SHA256SUMS` | 1 KB | [⬇️ Download](https://github.com/redtidev1918/daviewer/releases/download/v0.2.184/SHA256SUMS) |

--- a/docs/en/networking.md
+++ b/docs/en/networking.md
@@ -1,0 +1,99 @@
+# Networking and proxy
+
+**Language / 语言:** [中文](/networking.md) · English
+
+DAViewer separates two routes that the operating system genuinely separates:
+
+- **App traffic**: OAuth token exchange, API, images, video, downloads, and
+  hidden public website adapters.
+- **System-browser traffic**: the one official sign-in/registration page and
+  any DeviantArt, Google, Apple, Facebook, or verification pages it opens.
+
+The app can configure its own route but cannot silently reconfigure an external
+browser. UI and diagnostics must describe this boundary instead of promising
+that one successful test covers both routes.
+
+## Selection and persistence
+
+The App runtime priority is:
+
+1. a persisted in-app manual proxy;
+2. the OS system proxy (`scutil` on macOS, registry on Windows, GNOME manual
+   HTTPS/HTTP settings on Linux);
+3. `https_proxy`, `http_proxy`, or `all_proxy` (lowercase and uppercase);
+4. `DAKIT_PROXY_URL` supplied at build time;
+5. direct connection.
+
+The settings screen accepts an HTTP CONNECT proxy as `host:port` or a full URL
+such as `http://127.0.0.1:<PORT>`. `<PORT>` is a placeholder: users enter the
+HTTP/Mixed listener displayed by their own proxy app. On mobile,
+`127.0.0.1` means the proxy runs on that same phone. A proxy on a computer or
+router requires its LAN IP and an enabled “allow LAN” option.
+
+`export all_proxy=http://127.0.0.1:<PORT>` works when launching from that shell.
+Finder, Start Menu, and most desktop launchers do not inherit the variable, so
+release users should prefer the persisted App setting for App traffic and a
+system proxy or VPN for browser sign-in.
+
+Clearing the manual setting immediately re-runs automatic detection. The
+connectivity test sends a bounded DeviantArt request through the effective App
+route. It reports App reachability only; detailed socket errors remain in
+Diagnostics.
+
+## Platform coverage
+
+| Platform | App API / media / downloads | Hidden public browser adapter | Sign-in WebView |
+| --- | --- | --- | --- |
+| Android | system/VPN or dynamic App proxy | process-wide WebView override | same process-wide WebView override |
+| Windows | dynamic App proxy | shared WebView2 `--proxy-server` | same shared WebView2 `--proxy-server` |
+| macOS 14+ | dynamic App proxy | `WKWebsiteDataStore.proxyConfigurations` | same `WKWebsiteDataStore.proxyConfigurations` |
+| macOS 12/13 | dynamic App proxy | OS system proxy only | OS system proxy only |
+| Linux | not a current build target (no `linux/` platform directory; CI builds Android/macOS/Windows only) | — | — |
+
+If Linux support is added later, note that on GNOME `none` ignores stale
+host/port values and `manual` prefers HTTPS before HTTP, and PAC `auto` cannot
+be represented by `dart:io`'s static proxy directive — DAViewer would log the
+limitation and continue to environment, build-time, or direct fallback.
+
+Windows hidden WebViews and cookie reads share one WebView2 environment. This
+keeps public adapter cookies and proxy behavior consistent; it is not a second
+authentication session.
+
+## Sign-in recovery flow
+
+The login route starts with native UI. It exposes one official sign-in action,
+the current effective App route, proxy settings, a connectivity test, and public
+Settings/Diagnostics routes.
+
+OAuth opens once in the app's embedded WebView, on the same network path as the
+hidden adapter. DeviantArt's page decides which account and provider controls are
+available. The user can close and reopen the login screen or cancel the pending
+PKCE transaction. On Windows, the ZIP build registers `dakit://oauth/callback`
+below `HKCU\\Software\\Classes\\dakit` for the external-browser fallback and
+forwards a second-process activation to the running app.
+
+Provider and edge security checks can intentionally return HTTP 403, 429, or
+503 while presenting an interactive page. They are completed inside the embedded
+WebView. DAViewer neither labels those pages as an App connection failure nor
+attempts brittle DOM detection. If the WebView cannot reach the page, users fix
+the App route (proxy/VPN); the App connectivity test reports that same route.
+
+## Maintainer checks
+
+Before a network or authentication release:
+
+1. verify direct, automatic, manual, environment, and clearing behavior;
+2. test `all_proxy=http://127.0.0.1:<port>` with working and stopped proxies;
+3. verify App connectivity copy does not claim to test an external browser;
+4. complete DeviantArt and available social-provider authorization in the
+   embedded WebView, including callback, close/reopen, cancel, and cold-start
+   callback;
+5. verify a provider challenge remains entirely in the interactive WebView and
+   the App keeps waiting without a false network verdict;
+6. verify successful authorization opens Home recommendations without another
+   login or web-session prompt;
+7. verify hidden public adapters can refresh anonymously and degrade without a
+   login prompt;
+8. on Windows, verify protocol registration, process forwarding, and a moved
+   release folder;
+9. keep raw proxy, HTTP, parsing, and package details in Diagnostics only.

--- a/docs/en/web_adapter.md
+++ b/docs/en/web_adapter.md
@@ -1,0 +1,102 @@
+# Web adapter — compatibility contract
+
+**Language / 语言:** [中文](/web_adapter.md) · English
+
+DAViewer talks to two DeviantArt surfaces:
+
+- **Official OAuth API** (stable, versioned, owned by DAKit).
+- **Website-private JSON/HTML endpoints** (unstable, undocumented) for the few
+  detail features the official API does not expose: numeric-id resolution,
+  related-artwork blocks, collection full contents, real deviation search,
+  gallery keyword search, and profile facts (watchers/join date).
+
+This document is the compatibility contract for that second, private surface.
+Its job is not to prevent DeviantArt from changing — that is out of our
+control — but to make any change **cheap to detect and cheap to fix**.
+
+## Where the code lives
+
+These modules are intentionally kept in DAViewer (not in DAKit, not in a
+separate published package). They depend on undocumented, volatile endpoints,
+so publishing them would promise a stability that does not exist. They are
+grouped under `lib/core/data/` and must never leak HTML/JSON parsing into
+feature code.
+
+## The three-layer defense
+
+1. **Stable interface isolation.** Feature code depends on a small interface or
+   a DAKit domain model (`CollectionContentsSource.contents`, `Artwork`,
+   `DeviationInit`), never on raw HTML/JSON. A site change is fixed inside one
+   adapter without touching a screen.
+
+2. **Tolerant parsing + graceful degradation.** Every adapter parses
+   defensively (a malformed entry is skipped, not fatal) and has a fallback:
+   the official API, the preview data, or simply hiding the optional section.
+   A web failure must never take down the artwork detail page.
+
+3. **Contract tests against captured snapshots.** Each parser has a committed
+   unit test with a synthetic fixture, plus a gated live-snapshot test that
+   reads a real captured page when the corresponding `DA_*` dart-define points
+   at it. When DeviantArt changes shape, the snapshot test turns red and names
+   the exact parser.
+
+## Endpoint registry
+
+| Feature | Module | Endpoint / source | Session | Fallback | Contract test (snapshot define) |
+| --- | --- | --- | --- | --- | --- |
+| Personalized home feed | `rfy_feed.dart` | `_puppy/dabrowse/networkbar/rfy/deviations` | web Cookie + CSRF (signed-in) | none (needs the web session; shows sign-in prompt) | `rfy_feed_test.dart` — `updatedTime ?? publishedTime` feeds the artwork timestamp so ordering reflects edits |
+| Numeric→UUID + description + dates | `deviation_init.dart` | `_puppy/dadeviation/init` | anonymous browser CSRF | description falls back to the short excerpt; tags empty (official `deviation/metadata` serves only OAuth items); dates fall back to the feed item's publish time | `deviation_init_test.dart` (`DA_DEVIATION_INIT_JSON`) — also parses `publishedTime` / `updatedTime` for the detail date rows |
+| Related artwork | `web_more_like_this.dart` | artwork page `__INITIAL_STATE__` / `__RCACHE__` | none (public) | official `browse/morelikethis` | `web_more_like_this_test.dart` (`DA_MORE_LIKE_THIS_HTML`) |
+| Collection full contents | `web_collection_contents.dart` | `_puppy/dashared/gallection/contents` (JSON), fallback `deviantart.com/{user}/favourites/{id}?page=N` | anonymous browser CSRF (JSON) / none (SSR) | preview deviations + open-on-web | `web_collection_contents_test.dart` (`DA_COLLECTION_JSON`, `DA_COLLECTION_HTML`) |
+| Deviation search | `web_search.dart` | `_puppy/dabrowse/search/deviations` | web Cookie + CSRF (signed-in) | official `browse/home?q=` (coarse, no web session) | `web_search_test.dart` |
+| Gallery keyword search | `web_gallery_search.dart` | `_puppy/dashared/gallection/search` | anonymous browser CSRF | none (search needs the web session) | `web_gallery_search_test.dart` |
+| Profile facts (watchers/join date) | `web_user_profile.dart` | `_puppy/dauserprofile/init/about` | anonymous browser CSRF | none (header omits the enrichment) | `web_user_profile_test.dart` |
+
+Shared, non-endpoint helpers (no separate fallback, tested directly):
+
+| Helper | Module | Purpose | Test |
+| --- | --- | --- | --- |
+| Wix media descriptor → URL | `wix_media.dart` | `baseUri` + `prettyName` + `types` resolution | `wix_media_test.dart` |
+| JS literal JSON decoder | `html_state.dart` | `window.__X = JSON.parse("…")` decoding | via the snapshot tests above |
+| HTML / tiptap → text/html | `html_text.dart` | description rendering | `html_text_test.dart` |
+| Public browser state | `web_session.dart` | read anonymous browser cookies | `web_session_refresh_policy_test.dart` |
+| Link → route | `da_uri.dart` | paste-link parsing (no network) | `da_uri_test.dart` |
+
+Sections that are derived or use the official API (`more_from_artist`,
+`similar_artists`) are **not** web adapters and are excluded here.
+
+## When DeviantArt changes: runbook
+
+1. **Run the snapshot tests** with the latest capture to see which parser broke:
+
+   ```bash
+   flutter test --dart-define=DA_MORE_LIKE_THIS_HTML=/path/to/artwork.html \
+                --dart-define=DA_COLLECTION_HTML=/path/to/folder.html \
+                --dart-define=DA_DEVIATION_INIT_JSON=/path/to/init.json
+   ```
+
+2. **Isolate the failure** to one adapter. A red snapshot means "the shape of
+   that one endpoint changed", not "the app is broken".
+
+3. **Fix the parser** in that one file, keeping the mapped DAKit model
+   unchanged. Prefer tolerant reads (skip the bad entry) over strict parsing
+   unless the endpoint is wholly gone.
+
+4. **Refresh the snapshot** and re-run; then update the endpoint registry above
+   if the URL or fallback changed.
+
+5. **If the endpoint is removed**, do not invent a replacement. Swap in the
+   official API path or hide the section, and update the fallback column here.
+
+## Capturing snapshots
+
+Snapshots are real responses saved locally (they are **not** committed — they
+are large and change every time the site does). To capture one:
+
+- **Public pages** (artwork, collection): save the page HTML with a browser
+  User-Agent (login not required).
+- **Browser-shaped endpoints** (`dadeviation/init`): capture the JSON response
+  from a public browser session. Do not include account cookies in fixtures.
+
+The `DA_*` dart-defines point at those files; when unset, the gated tests skip,
+so CI never depends on a captured page.

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,6 +51,9 @@
       nameLink: '#/',
       repo: 'redtidev1918/daviewer',
       loadSidebar: true,
+      alias: {
+        '/.*/_sidebar.md': '/_sidebar.md'
+      },
       subMaxLevel: 2,
       maxLevel: 3,
       auto2top: true,

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,97 +1,62 @@
-# Networking and proxy
+# 网络与代理
 
-DAViewer separates two routes that the operating system genuinely separates:
+> English: [Networking and proxy](/en/networking.md)
 
-- **App traffic**: OAuth token exchange, API, images, video, downloads, and
-  hidden public website adapters.
-- **System-browser traffic**: the one official sign-in/registration page and
-  any DeviantArt, Google, Apple, Facebook, or verification pages it opens.
+DAViewer 区分两条操作系统本身也区分的路由：
 
-The app can configure its own route but cannot silently reconfigure an external
-browser. UI and diagnostics must describe this boundary instead of promising
-that one successful test covers both routes.
+- **应用流量**：OAuth token 交换、API、图片、视频、下载，以及隐藏的公开网页适配器。
+- **系统浏览器流量**：唯一的官方登录/注册页，以及它打开的 DeviantArt、Google、Apple、Facebook 或验证页面。
 
-## Selection and persistence
+应用可以配置自己的路由，但无法静默重配外部浏览器。UI 与诊断必须如实描述这条边界，不能承诺一次成功的连通性测试覆盖了两条路由。
 
-The App runtime priority is:
+## 选择与持久化
 
-1. a persisted in-app manual proxy;
-2. the OS system proxy (`scutil` on macOS, registry on Windows, GNOME manual
-   HTTPS/HTTP settings on Linux);
-3. `https_proxy`, `http_proxy`, or `all_proxy` (lowercase and uppercase);
-4. `DAKIT_PROXY_URL` supplied at build time;
-5. direct connection.
+应用运行时的优先级为：
 
-The settings screen accepts an HTTP CONNECT proxy as `host:port` or a full URL
-such as `http://127.0.0.1:<PORT>`. `<PORT>` is a placeholder: users enter the
-HTTP/Mixed listener displayed by their own proxy app. On mobile,
-`127.0.0.1` means the proxy runs on that same phone. A proxy on a computer or
-router requires its LAN IP and an enabled “allow LAN” option.
+1. 持久化的应用内手动代理；
+2. 操作系统系统代理（macOS 用 `scutil`，Windows 用注册表，Linux 用 GNOME 手动 HTTPS/HTTP 设置）；
+3. `https_proxy`、`http_proxy` 或 `all_proxy`（大小写均支持）；
+4. 构建期传入的 `DAKIT_PROXY_URL`；
+5. 直连。
 
-`export all_proxy=http://127.0.0.1:<PORT>` works when launching from that shell.
-Finder, Start Menu, and most desktop launchers do not inherit the variable, so
-release users should prefer the persisted App setting for App traffic and a
-system proxy or VPN for browser sign-in.
+设置界面接受 HTTP CONNECT 代理，形式为 `host:port` 或完整 URL，例如 `http://127.0.0.1:<PORT>`。`<PORT>` 是占位符：用户需填入自己代理应用显示的 HTTP/Mixed 监听端口。在移动端，`127.0.0.1` 表示代理运行在同一台手机上。电脑或路由器上的代理需要其局域网 IP，并开启「允许局域网」选项。
 
-Clearing the manual setting immediately re-runs automatic detection. The
-connectivity test sends a bounded DeviantArt request through the effective App
-route. It reports App reachability only; detailed socket errors remain in
-Diagnostics.
+从某个 shell 启动时 `export all_proxy=http://127.0.0.1:<PORT>` 有效。Finder、开始菜单与多数桌面启动器不会继承该变量，因此正式用户的应用流量应优先使用持久化的应用内设置，浏览器登录则使用系统代理或 VPN。
 
-## Platform coverage
+清除手动设置会立即重新执行自动探测。连通性测试通过生效的应用路由发送一个有时限的 DeviantArt 请求。它只报告**应用侧**可达性；详细的 socket 错误留在「诊断」中。
 
-| Platform | App API / media / downloads | Hidden public browser adapter | Sign-in WebView |
+## 平台覆盖
+
+| 平台 | 应用 API / 媒体 / 下载 | 隐藏的公开浏览器适配器 | 登录 WebView |
 | --- | --- | --- | --- |
-| Android | system/VPN or dynamic App proxy | process-wide WebView override | same process-wide WebView override |
-| Windows | dynamic App proxy | shared WebView2 `--proxy-server` | same shared WebView2 `--proxy-server` |
-| macOS 14+ | dynamic App proxy | `WKWebsiteDataStore.proxyConfigurations` | same `WKWebsiteDataStore.proxyConfigurations` |
-| macOS 12/13 | dynamic App proxy | OS system proxy only | OS system proxy only |
-| Linux | not a current build target (no `linux/` platform directory; CI builds Android/macOS/Windows only) | — | — |
+| Android | 系统/VPN 或动态应用代理 | 进程级 WebView 覆盖 | 同一进程级 WebView 覆盖 |
+| Windows | 动态应用代理 | 共享 WebView2 `--proxy-server` | 同一共享 WebView2 `--proxy-server` |
+| macOS 14+ | 动态应用代理 | `WKWebsiteDataStore.proxyConfigurations` | 同一 `WKWebsiteDataStore.proxyConfigurations` |
+| macOS 12/13 | 动态应用代理 | 仅操作系统系统代理 | 仅操作系统系统代理 |
+| Linux | 非当前构建目标（无 `linux/` 平台目录；CI 仅构建 Android/macOS/Windows） | — | — |
 
-If Linux support is added later, note that on GNOME `none` ignores stale
-host/port values and `manual` prefers HTTPS before HTTP, and PAC `auto` cannot
-be represented by `dart:io`'s static proxy directive — DAViewer would log the
-limitation and continue to environment, build-time, or direct fallback.
+若日后加入 Linux 支持，注意 GNOME 下 `none` 会忽略过期的 host/port，`manual` 优先 HTTPS 再 HTTP，而 PAC `auto` 无法用 `dart:io` 的静态代理指令表达——届时 DAViewer 应记录该限制并继续回退到环境变量、构建期注入或直连。
 
-Windows hidden WebViews and cookie reads share one WebView2 environment. This
-keeps public adapter cookies and proxy behavior consistent; it is not a second
-authentication session.
+Windows 的隐藏 WebView 与 Cookie 读取共用同一个 WebView2 环境。这保证公开适配器的 Cookie 与代理行为一致；它不是第二个认证会话。
 
-## Sign-in recovery flow
+## 登录恢复流程
 
-The login route starts with native UI. It exposes one official sign-in action,
-the current effective App route, proxy settings, a connectivity test, and public
-Settings/Diagnostics routes.
+登录路由以内置原生 UI 开始，暴露一个官方登录操作、当前生效的应用路由、代理设置、连通性测试，以及公开的「设置/诊断」路由。
 
-OAuth opens once in the app's embedded WebView, on the same network path as the
-hidden adapter. DeviantArt's page decides which account and provider controls are
-available. The user can close and reopen the login screen or cancel the pending
-PKCE transaction. On Windows, the ZIP build registers `dakit://oauth/callback`
-below `HKCU\\Software\\Classes\\dakit` for the external-browser fallback and
-forwards a second-process activation to the running app.
+OAuth 在应用内嵌 WebView 中打开一次，与隐藏适配器走同一条网络路径。由 DeviantArt 页面决定可用哪些账号与服务商控件。用户可以关闭并重新打开登录界面，或取消待处理的 PKCE 事务。在 Windows 上，ZIP 版会在 `HKCU\Software\Classes\dakit` 下注册 `dakit://oauth/callback` 以支持外部浏览器回退，并把第二次进程激活转发给正在运行的应用。
 
-Provider and edge security checks can intentionally return HTTP 403, 429, or
-503 while presenting an interactive page. They are completed inside the embedded
-WebView. DAViewer neither labels those pages as an App connection failure nor
-attempts brittle DOM detection. If the WebView cannot reach the page, users fix
-the App route (proxy/VPN); the App connectivity test reports that same route.
+服务商与边缘安全校验可能故意返回 HTTP 403、429 或 503 同时呈现交互页面。这些都在内嵌 WebView 内完成。DAViewer 既不把这些页面标记为应用连接失败，也不尝试脆弱的 DOM 探测。若 WebView 无法访问该页面，用户应修复应用路由（代理/VPN）；应用连通性测试报告的正是同一条路由。
 
-## Maintainer checks
+## 维护者检查项
 
-Before a network or authentication release:
+网络或认证相关发版之前：
 
-1. verify direct, automatic, manual, environment, and clearing behavior;
-2. test `all_proxy=http://127.0.0.1:<port>` with working and stopped proxies;
-3. verify App connectivity copy does not claim to test an external browser;
-4. complete DeviantArt and available social-provider authorization in the
-   embedded WebView, including callback, close/reopen, cancel, and cold-start
-   callback;
-5. verify a provider challenge remains entirely in the interactive WebView and
-   the App keeps waiting without a false network verdict;
-6. verify successful authorization opens Home recommendations without another
-   login or web-session prompt;
-7. verify hidden public adapters can refresh anonymously and degrade without a
-   login prompt;
-8. on Windows, verify protocol registration, process forwarding, and a moved
-   release folder;
-9. keep raw proxy, HTTP, parsing, and package details in Diagnostics only.
+1. 验证直连、自动、手动、环境变量与清除行为；
+2. 用可用与已停止的代理分别测试 `all_proxy=http://127.0.0.1:<port>`；
+3. 确认应用连通性文案没有声称测试了外部浏览器；
+4. 在内嵌 WebView 中完成 DeviantArt 与可用社交服务商的授权，覆盖回调、关闭/重开、取消与冷启动回调；
+5. 确认服务商挑战完全停留在交互式 WebView 内，应用持续等待且不误判为网络故障；
+6. 确认授权成功后直接进入首页推荐，不再要求登录或网页会话提示；
+7. 确认隐藏的公开适配器能匿名刷新并在无登录提示的情况下降级；
+8. 在 Windows 上验证协议注册、进程转发与移动后的发布目录；
+9. 原始代理、HTTP、解析与包细节只留在「诊断」中。

--- a/docs/web_adapter.md
+++ b/docs/web_adapter.md
@@ -1,71 +1,53 @@
-# Web adapter — compatibility contract
+# 网页适配器 —— 兼容性契约
 
-DAViewer talks to two DeviantArt surfaces:
+> English: [Web adapter — compatibility contract](/en/web_adapter.md)
 
-- **Official OAuth API** (stable, versioned, owned by DAKit).
-- **Website-private JSON/HTML endpoints** (unstable, undocumented) for the few
-  detail features the official API does not expose: numeric-id resolution,
-  related-artwork blocks, collection full contents, real deviation search,
-  gallery keyword search, and profile facts (watchers/join date).
+DAViewer 与两个 DeviantArt 表面通信：
 
-This document is the compatibility contract for that second, private surface.
-Its job is not to prevent DeviantArt from changing — that is out of our
-control — but to make any change **cheap to detect and cheap to fix**.
+- **官方 OAuth API**（稳定、有版本、由 DAKit 负责）。
+- **网站私有 JSON/HTML 接口**（不稳定、未公开），用于官方 API 未暴露的少数详情功能：数字 id 解析、相关作品区块、合集完整内容、真正的作品搜索、画廊关键词搜索，以及个人资料事实（关注者数/加入日期）。
 
-## Where the code lives
+本文是第二个私有表面的兼容性契约。它的目标不是阻止 DeviantArt 变更——那不在我们控制之内——而是让任何变更**易于发现、易于修复**。
 
-These modules are intentionally kept in DAViewer (not in DAKit, not in a
-separate published package). They depend on undocumented, volatile endpoints,
-so publishing them would promise a stability that does not exist. They are
-grouped under `lib/core/data/` and must never leak HTML/JSON parsing into
-feature code.
+## 代码位置
 
-## The three-layer defense
+这些模块刻意保留在 DAViewer 中（不放 DAKit，也不单独发包）。它们依赖未公开、易变的端点，发布出去就等于承诺一种并不存在的稳定性。它们集中在 `lib/core/data/` 下，且绝不允许把 HTML/JSON 解析泄漏进业务代码。
 
-1. **Stable interface isolation.** Feature code depends on a small interface or
-   a DAKit domain model (`CollectionContentsSource.contents`, `Artwork`,
-   `DeviationInit`), never on raw HTML/JSON. A site change is fixed inside one
-   adapter without touching a screen.
+## 三层防御
 
-2. **Tolerant parsing + graceful degradation.** Every adapter parses
-   defensively (a malformed entry is skipped, not fatal) and has a fallback:
-   the official API, the preview data, or simply hiding the optional section.
-   A web failure must never take down the artwork detail page.
+1. **稳定接口隔离。** 业务代码只依赖一个小接口或 DAKit 领域模型（`CollectionContentsSource.contents`、`Artwork`、`DeviationInit`），绝不依赖原始 HTML/JSON。站点变更在一个适配器内修好，不必碰任何界面。
 
-3. **Contract tests against captured snapshots.** Each parser has a committed
-   unit test with a synthetic fixture, plus a gated live-snapshot test that
-   reads a real captured page when the corresponding `DA_*` dart-define points
-   at it. When DeviantArt changes shape, the snapshot test turns red and names
-   the exact parser.
+2. **宽容解析 + 优雅降级。** 每个适配器都防御式解析（单条畸形数据跳过，而不是致命错误），并带有回退：官方 API、预览数据，或直接隐藏该可选区块。网页失败绝不能拖垮作品详情页。
 
-## Endpoint registry
+3. **针对抓取快照的契约测试。** 每个解析器都有一个使用合成 fixture 的提交式单元测试，外加一个受门控的实时快照测试——当对应的 `DA_*` dart-define 指向真实抓取页面时才会读取。DeviantArt 结构一变，快照测试就会变红并直接点名是哪个解析器。
 
-| Feature | Module | Endpoint / source | Session | Fallback | Contract test (snapshot define) |
+## 端点注册表
+
+| 功能 | 模块 | 端点 / 数据源 | 会话 | 回退 | 契约测试（快照 define） |
 | --- | --- | --- | --- | --- | --- |
-| Personalized home feed | `rfy_feed.dart` | `_puppy/dabrowse/networkbar/rfy/deviations` | web Cookie + CSRF (signed-in) | none (needs the web session; shows sign-in prompt) | `rfy_feed_test.dart` — `updatedTime ?? publishedTime` feeds the artwork timestamp so ordering reflects edits |
-| Numeric→UUID + description + dates | `deviation_init.dart` | `_puppy/dadeviation/init` | anonymous browser CSRF | description falls back to the short excerpt; tags empty (official `deviation/metadata` serves only OAuth items); dates fall back to the feed item's publish time | `deviation_init_test.dart` (`DA_DEVIATION_INIT_JSON`) — also parses `publishedTime` / `updatedTime` for the detail date rows |
-| Related artwork | `web_more_like_this.dart` | artwork page `__INITIAL_STATE__` / `__RCACHE__` | none (public) | official `browse/morelikethis` | `web_more_like_this_test.dart` (`DA_MORE_LIKE_THIS_HTML`) |
-| Collection full contents | `web_collection_contents.dart` | `_puppy/dashared/gallection/contents` (JSON), fallback `deviantart.com/{user}/favourites/{id}?page=N` | anonymous browser CSRF (JSON) / none (SSR) | preview deviations + open-on-web | `web_collection_contents_test.dart` (`DA_COLLECTION_JSON`, `DA_COLLECTION_HTML`) |
-| Deviation search | `web_search.dart` | `_puppy/dabrowse/search/deviations` | web Cookie + CSRF (signed-in) | official `browse/home?q=` (coarse, no web session) | `web_search_test.dart` |
-| Gallery keyword search | `web_gallery_search.dart` | `_puppy/dashared/gallection/search` | anonymous browser CSRF | none (search needs the web session) | `web_gallery_search_test.dart` |
-| Profile facts (watchers/join date) | `web_user_profile.dart` | `_puppy/dauserprofile/init/about` | anonymous browser CSRF | none (header omits the enrichment) | `web_user_profile_test.dart` |
+| 个性化首页信息流 | `rfy_feed.dart` | `_puppy/dabrowse/networkbar/rfy/deviations` | 网页 Cookie + CSRF（已登录） | 无（需要网页会话；展示登录提示） | `rfy_feed_test.dart` —— `updatedTime ?? publishedTime` 提供给作品时间戳，使排序反映编辑 |
+| 数字→UUID + 简介 + 日期 | `deviation_init.dart` | `_puppy/dadeviation/init` | 匿名浏览器 CSRF | 简介回退到短摘要；标签为空（官方 `deviation/metadata` 只服务 OAuth 作品）；日期回退到信息流条目的发布时间 | `deviation_init_test.dart`（`DA_DEVIATION_INIT_JSON`）—— 同时解析 `publishedTime` / `updatedTime` 供详情页日期行使用 |
+| 相关作品 | `web_more_like_this.dart` | 作品页 `__INITIAL_STATE__` / `__RCACHE__` | 无（公开） | 官方 `browse/morelikethis` | `web_more_like_this_test.dart`（`DA_MORE_LIKE_THIS_HTML`） |
+| 合集完整内容 | `web_collection_contents.dart` | `_puppy/dashared/gallection/contents`（JSON），回退 `deviantart.com/{user}/favourites/{id}?page=N` | 匿名浏览器 CSRF（JSON）/ 无（SSR） | 预览作品 + 在网页中打开 | `web_collection_contents_test.dart`（`DA_COLLECTION_JSON`、`DA_COLLECTION_HTML`） |
+| 作品搜索 | `web_search.dart` | `_puppy/dabrowse/search/deviations` | 网页 Cookie + CSRF（已登录） | 官方 `browse/home?q=`（粗粒度，无需网页会话） | `web_search_test.dart` |
+| 画廊关键词搜索 | `web_gallery_search.dart` | `_puppy/dashared/gallection/search` | 匿名浏览器 CSRF | 无（搜索需要网页会话） | `web_gallery_search_test.dart` |
+| 个人资料事实（关注者/加入日期） | `web_user_profile.dart` | `_puppy/dauserprofile/init/about` | 匿名浏览器 CSRF | 无（响应头缺少该富信息） | `web_user_profile_test.dart` |
 
-Shared, non-endpoint helpers (no separate fallback, tested directly):
+共享的、非端点辅助模块（无独立回退，直接测试）：
 
-| Helper | Module | Purpose | Test |
+| 辅助 | 模块 | 用途 | 测试 |
 | --- | --- | --- | --- |
-| Wix media descriptor → URL | `wix_media.dart` | `baseUri` + `prettyName` + `types` resolution | `wix_media_test.dart` |
-| JS literal JSON decoder | `html_state.dart` | `window.__X = JSON.parse("…")` decoding | via the snapshot tests above |
-| HTML / tiptap → text/html | `html_text.dart` | description rendering | `html_text_test.dart` |
-| Public browser state | `web_session.dart` | read anonymous browser cookies | `web_session_refresh_policy_test.dart` |
-| Link → route | `da_uri.dart` | paste-link parsing (no network) | `da_uri_test.dart` |
+| Wix 媒体描述 → URL | `wix_media.dart` | `baseUri` + `prettyName` + `types` 解析 | `wix_media_test.dart` |
+| JS 字面量 JSON 解码 | `html_state.dart` | `window.__X = JSON.parse("…")` 解码 | 由上面的快照测试覆盖 |
+| HTML / tiptap → 文本/HTML | `html_text.dart` | 简介渲染 | `html_text_test.dart` |
+| 公开浏览器状态 | `web_session.dart` | 读取匿名浏览器 Cookie | `web_session_refresh_policy_test.dart` |
+| 链接 → 路由 | `da_uri.dart` | 粘贴链接解析（无网络） | `da_uri_test.dart` |
 
-Sections that are derived or use the official API (`more_from_artist`,
-`similar_artists`) are **not** web adapters and are excluded here.
+派生区块或使用官方 API 的区块（`more_from_artist`、`similar_artists`）**不是**网页适配器，不在此列。
 
-## When DeviantArt changes: runbook
+## DeviantArt 变更时的排查手册
 
-1. **Run the snapshot tests** with the latest capture to see which parser broke:
+1. **用最新抓取运行快照测试**，看是哪个解析器坏了：
 
    ```bash
    flutter test --dart-define=DA_MORE_LIKE_THIS_HTML=/path/to/artwork.html \
@@ -73,28 +55,19 @@ Sections that are derived or use the official API (`more_from_artist`,
                 --dart-define=DA_DEVIATION_INIT_JSON=/path/to/init.json
    ```
 
-2. **Isolate the failure** to one adapter. A red snapshot means "the shape of
-   that one endpoint changed", not "the app is broken".
+2. **把失败定位到一个适配器**。快照变红意味着「那一个端点的结构变了」，而不是「应用坏了」。
 
-3. **Fix the parser** in that one file, keeping the mapped DAKit model
-   unchanged. Prefer tolerant reads (skip the bad entry) over strict parsing
-   unless the endpoint is wholly gone.
+3. **只在那一个文件里修解析器**，保持映射出的 DAKit 模型不变。除非端点彻底消失，否则优先宽容读取（跳过坏条目）而非严格解析。
 
-4. **Refresh the snapshot** and re-run; then update the endpoint registry above
-   if the URL or fallback changed.
+4. **刷新快照**并重跑；若 URL 或回退变了，同步更新上面的端点注册表。
 
-5. **If the endpoint is removed**, do not invent a replacement. Swap in the
-   official API path or hide the section, and update the fallback column here.
+5. **若端点被移除**，不要臆造替代品。改用官方 API 路径或隐藏该区块，并更新此处的回退列。
 
-## Capturing snapshots
+## 抓取快照
 
-Snapshots are real responses saved locally (they are **not** committed — they
-are large and change every time the site does). To capture one:
+快照是本地保存的真实响应（**不提交**——它们体积大且随站点每次变更而变）。抓取方式：
 
-- **Public pages** (artwork, collection): save the page HTML with a browser
-  User-Agent (login not required).
-- **Browser-shaped endpoints** (`dadeviation/init`): capture the JSON response
-  from a public browser session. Do not include account cookies in fixtures.
+- **公开页面**（作品、合集）：用浏览器 User-Agent 保存页面 HTML（无需登录）。
+- **浏览器形态端点**（`dadeviation/init`）：从公开浏览器会话抓取 JSON 响应。fixture 中不要包含账号 Cookie。
 
-The `DA_*` dart-defines point at those files; when unset, the gated tests skip,
-so CI never depends on a captured page.
+`DA_*` dart-define 指向这些文件；未设置时受门控的测试会跳过，因此 CI 永不依赖抓取页面。


### PR DESCRIPTION
## 目标

按 docsite 统一文档规范（redtidev1918/docsite#1）对齐 daviewer。

## 本仓库的特殊情况

daviewer 是本账号唯一「开发者文档**只有英文**」的仓库，而且这是**写进文档的刻意约定**——原 `docs/README.md` 明确写着「面向用户页面（本页、下载页）为中文，开发者文档正文用英文」。

这与账号规范（`docs/` 根 = 中文，`docs/en/` = 英文，中英一一对应）直接冲突。本 PR 按新规范处理，同时**保留英文原文**：

| 原路径 | 语言 | 新路径 |
| :-- | :-- | :-- |
| `docs/architecture.md` | 英文 | `docs/en/architecture.md` |
| `docs/authentication.md` | 英文 | `docs/en/authentication.md` |
| `docs/networking.md` | 英文 | `docs/en/networking.md` |
| `docs/web_adapter.md` | 英文 | `docs/en/web_adapter.md` |
| `docs/build.md` | 英文 | `docs/en/build.md` |
| —— | 中文（**新增**） | `docs/architecture.md`、`docs/authentication.md`、`docs/networking.md`、`docs/web_adapter.md`、`docs/build.md` |

**新增的 5 篇中文文档是对应英文原文的逐节翻译**（含全部规则、表格与端点注册表），不是摘要；两页顶部互加语言切换链接。

## 结构改动

- `docs/_sidebar.md`：相对路径 → **根绝对路径** + 中文分组 + `English` 分组，中英条目一一对应
- `docs/index.html`：补 docsify `alias`（缺它时 `docs/en/**` 子页面加载不到根侧边栏）
- `docs/README.md`：重写为按新规范组织，并给出**中英对照表**（原「开发者文档用英文」的约定已更新）
- `docs/en/README.md`：新增英文文档首页

## 接入 docsite 托管下载页链路

- 生成器替换为 docsite 统一下发版本（带 `docsite-managed-file` / `-version` marker）
- 新增 `.github/workflows/update-download-page.yml`：`release: published` 后刷新两份下载页
- 新增 `.github/scripts/download-page.json`（非托管配置）声明 `displayName: DAViewer`

> 最后一点值得说明：原先 `daviewer` 的生成器里有一段**硬编码**的 `{"daviewer": "DAViewer"}` 映射，正是它导致这批生成器 md5 各不相同、无法批量套用补丁。现在差异下沉为配置文件，脚本本体与其它仓库**逐字节一致**。
>
> 顺带修掉一个真实缺陷：此前没有任何 workflow 调用生成器，下载页「每次发版自动更新」是假的。

## 同步引用

- `README.en.md`：`docs/*.md` 引用全部改指 `docs/en/*.md`（中文 README 的引用无需改动，中文文档仍在 `docs/` 根）

## 验证

- `python3 ../docsite/docsite.py check .` → 托管文件与模板**逐字节一致**（2/2 ok）
- `python3 .github/scripts/update_download_page.py` 本地运行通过，中英两页资产表一致（v0.2.184，8 个资产）
- 中英页面路径双向可达：`/architecture.md` ↔ `/en/architecture.md` 等 5 组