### PR TITLE
docs: simplify navigation and split locale sidebars

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,19 +1,10 @@
 - 开始
-  - [文档中心](/)
+  - [概览](/)
   - [📥 下载](/download.md)
-- 架构与设计
-  - [架构说明](/architecture.md)
-  - [网页适配器 —— 兼容性契约](/web_adapter.md)
-- 认证与网络
+- 使用与配置
   - [认证与会话恢复](/authentication.md)
   - [网络与代理](/networking.md)
-- 构建与发布
+- 开发
+  - [架构说明](/architecture.md)
+  - [Web 适配器契约](/web_adapter.md)
   - [构建说明](/build.md)
-- English
-  - [Documentation](/en/)
-  - [📥 Download](/en/download.md)
-  - [Architecture](/en/architecture.md)
-  - [Web adapter — compatibility contract](/en/web_adapter.md)
-  - [Authentication and session recovery](/en/authentication.md)
-  - [Networking and proxy](/en/networking.md)
-  - [Build notes](/en/build.md)

--- a/docs/en/_sidebar.md
+++ b/docs/en/_sidebar.md
@@ -1,0 +1,10 @@
+- Getting Started
+  - [Overview](/en/)
+  - [📥 Download](/en/download.md)
+- Usage & Configuration
+  - [Authentication & Session Recovery](/en/authentication.md)
+  - [Networking & Proxy](/en/networking.md)
+- Development
+  - [Architecture](/en/architecture.md)
+  - [Web Adapter Contract](/en/web_adapter.md)
+  - [Build](/en/build.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,9 @@
       nameLink: '#/',
       repo: 'redtidev1918/daviewer',
       loadSidebar: true,
+      // 语言是站点维度：/en/ 页面读英文侧边栏，根页面读中文侧边栏
       alias: {
+        '/en/.*/_sidebar.md': '/en/_sidebar.md',
         '/.*/_sidebar.md': '/_sidebar.md'
       },
       subMaxLevel: 2,


### PR DESCRIPTION
## 概要

DAViewer 作为[导航与信息架构规约](https://github.com/redtidev1918/docsite/pull/3)的**首个试点**：侧边栏从「长、重复、嵌套深、语言混杂」收敛为「短、平、任务导向、单语言」。

## 旧 → 新

**旧 sidebar（中文挂整棵英文树）：**

```text
开始
  文档中心
  📥 下载
架构与设计
  架构说明
  网页适配器
认证与网络
  认证与会话恢复
  网络与代理
构建与发布          ← 单页面顶级分类
  构建说明
English             ← 整棵英文文档树挂在中文 sidebar 底部
  Documentation / Download / Architecture / ...
```

**新 sidebar（`docs/_sidebar.md`，中文单语）：**

```text
开始
  概览
  📥 下载
使用与配置
  认证与会话恢复
  网络与代理
开发
  架构说明
  Web 适配器契约
  构建说明
```

**新 `docs/en/_sidebar.md`（英文单语，与中文语义对称、页面一一对应）：**

```text
Getting Started
  Overview
  📥 Download
Usage & Configuration
  Authentication & Session Recovery
  Networking & Proxy
Development
  Architecture
  Web Adapter Contract
  Build
```

## 删除项与对应规约

| 删除 | 规约 |
| :-- | :-- |
| `English` 整组 | 根 sidebar 不含 /en/ 文档树（`COMBINED_LOCALES`） |
| 「文档中心」命名 | 首页在 sidebar 叫「概览」（Overview） |
| 单页面顶级分类「构建与发布」 | 顶级分类通常 ≥2 页，并入「开发」 |
| 架构与设计 / 认证与网络 两个 2 页分类 | 任务导向重组：用户内容归「使用与配置」，维护者内容归「开发」 |

## Docsify locale 解析

`docs/index.html` 的 alias 从「所有路径强制根 sidebar」改为 locale 感知：

```js
alias: {
  '/en/.*/_sidebar.md': '/en/_sidebar.md',   // en 规则在前（first match wins）
  '/.*/_sidebar.md': '/_sidebar.md'
}
```

`/en/*` 页面读取英文侧边栏，根页面读取中文侧边栏，互不覆盖。

## 不改动

- README 内容不删：首页的下载 / 开发者 / 合规 / 相关 / 约定 section 原样保留，只是不再作为 sidebar 子导航（侧边栏简化 ≠ 首页内容删除）
- 不修改 runtime code，不发 release