### PR TITLE
fix: native per-directory sidebars; drop wildcard alias and heading injection

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -51,13 +51,10 @@
       nameLink: '#/',
       repo: 'redtidev1918/daviewer',
       loadSidebar: true,
-      // 语言是站点维度：/en/ 页面读英文侧边栏，根页面读中文侧边栏
-      alias: {
-        '/en/.*/_sidebar.md': '/en/_sidebar.md',
-        '/.*/_sidebar.md': '/_sidebar.md'
-      },
-      subMaxLevel: 2,
-      maxLevel: 3,
+      // 语言是站点维度：docsify 原生按页面所在目录取 _sidebar.md——
+      // 根页面读 /_sidebar.md，/en/ 页面读 /en/_sidebar.md，无需 alias。
+      // 注意：不要配置 '/.*/_sidebar.md' 之类的通配 alias，它会把 /en/_sidebar.md
+      // 改写回根侧边栏，破坏分语言导航；页内标题也不注入 sidebar（无 subMaxLevel）。
       auto2top: true,
       search: {
         placeholder: '搜索文档…',


### PR DESCRIPTION
## 背景

[导航与信息架构规约](https://github.com/redtidev1918/docsite/pull/3)试点（#23）的浏览器实测发现两个外壳层问题，导致验收第 3/5/10 条不过。

## 实测发现

1. **英文页渲染中文侧边栏**：完整加载 `#/en/README.md` 后 sidebar 仍是「开始 / 使用与配置 / 开发」。
   根因：docsify 对 sidebar **请求路径**做 alias 改写——`/.*/_sidebar.md` 能匹配 `/en/_sidebar.md`
   并改写回根侧边栏；而 `'/en/.*/_sidebar.md'` 匹配不到 `/en/_sidebar.md`（模式要求 `/en/` 后
   还有更深一层目录）。两条叠加，英文页被静默回退。
2. **页内标题注入 sidebar**：`subMaxLevel: 2` 把当前页（首页）的 H2 锚点动态嵌在「概览」条目下，
   页内目录混回导航——正是规约禁止的职责复制。

## 修复

- 移除 alias 与 `subMaxLevel`/`maxLevel`，依赖 docsify **原生按页面目录**解析侧边栏：
  根页面 → `/_sidebar.md`，`/en/` 页面 → `/en/_sidebar.md`（两种侧边栏均已存在）
- 留防回归注释，说明为什么不能配通配 alias

## 实机验证（本地 http.server + Chromium）

| 验收项 | 结果 |
| :-- | :-- |
| `/en/` 显示英文 sidebar | ✅ Getting Started / Usage & Configuration / Development |
| 中文页只显示中文 sidebar | ✅ 开始 / 使用与配置 / 开发 |
| README 页内 section 不出现在 sidebar | ✅（无标题注入，仅 分类→页面 两层） |
| 下载只出现一次 | ✅（仅 `开始 → 下载`） |
| architecture / auth / network / build 可导航 | ✅ 全部 200（18 个目标含双语文档） |
| 刷新深链接不 404 | ✅（hash 路由 + 全部静态文件存在） |

同步修改：docsite 模板同款变更 + `navcheck` 新增 `GLOBAL_SIDEBAR_ALIAS`（error）/ `HEADING_INJECTION`（warning）。

不改 runtime code，不发 release。