### PR TITLE
chore(governance): install the production-operation branch contract

### DIFF
--- a/.github/workflows/branch-contract.yml
+++ b/.github/workflows/branch-contract.yml
@@ -1,0 +1,16 @@
+name: Branch contract
+# Production-operation branch contract gate (see redtidev1918/releasegraph
+# docs/branch-contract.md). Feature PRs are skipped; a violating
+# cutover/release/hotfix/ops PR hard-fails with a diff proof.
+#
+# Pinned to the immutable ReleaseGraph v1.4.11 commit. v1.4.10 enforces engine
+# provenance (the gate builds and asserts its engine from job.workflow_sha, so
+# caller pin == engine version end to end); v1.4.11 evaluates the real PR head
+# commit (github.event.pull_request.head.sha) instead of the merge ref, whose
+# ancestry against the base is trivially clean.
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  branch-contract:
+    uses: redtidev1918/releasegraph/.github/workflows/reusable-branch-contract.yml@0b0c28990abac59aa5ae1d2c50bf95ce06d26a8d # ReleaseGraph v1.4.11

--- a/.release-policy.yml
+++ b/.release-policy.yml
@@ -43,5 +43,19 @@
     "failed_draft": 2
   },
   "checksums": true,
-  "sbom": false
+  "sbom": false,
+  "repository": {
+    "git": {
+      "productionOperations": {
+        "base": "default",
+        "branches": [
+          "chore/cutover-*",
+          "ops/*",
+          "release/*",
+          "hotfix/*"
+        ],
+        "requireLatestBase": true
+      }
+    }
+  }
 }


### PR DESCRIPTION
Installs the ReleaseGraph v1.4.11 production-operation branch contract:

- `.github/workflows/branch-contract.yml` — thin consumer caller pinned to the immutable commit `0b0c28990abac59aa5ae1d2c50bf95ce06d26a8d` (`# ReleaseGraph v1.4.11`).
- `.release-policy.yml` — declares `repository.git.productionOperations` with `base: default`, the standard production-operation branch patterns, and `requireLatestBase: true`.

Feature PRs are skipped by the gate; a violating cutover/release/hotfix/ops PR hard-fails with a diff proof. No `operations`/`allowedPaths` scope is declared — this repository has no production-transition history, and scope is an optional repo-level declaration.

Ref: redtidev1918/releasegraph `docs/branch-contract.md`.