### PR TITLE
fix(release): one canonical asset name per platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,25 @@ jobs:
       - run: flutter analyze
       - run: dart format --output=none --set-exit-if-changed lib test
       - run: flutter test
+      - name: Canonical release asset naming
+        shell: bash
+        run: |
+          # Exactly one shipped name per platform, always the `v`-prefixed form.
+          # A second, v-less convention does not overwrite anything: release
+          # uploads are additive, so it surfaces as a duplicate pair on the
+          # release (v0.2.184 carries both `DAViewer-0.2.184.apk` and
+          # `DAViewer-v0.2.184.apk`). Guard the producer and the collector.
+          set -euo pipefail
+          if grep -q 'DAViewer-\$RELEASE_VERSION' scripts/build-release; then
+            echo "::error::scripts/build-release writes a non-canonical (v-less) asset name"
+            exit 1
+          fi
+          grep -q 'DAViewer-v\$RELEASE_VERSION' scripts/build-release || {
+            echo "::error::scripts/build-release does not write the canonical v-prefixed names"
+            exit 1
+          }
+          grep -q 'DAViewer-v\*' .release-policy.yml || {
+            echo "::error::.release-policy.yml does not require canonical v-prefixed assets"
+            exit 1
+          }
+          echo "canonical release asset naming OK"

--- a/README.en.md
+++ b/README.en.md
@@ -24,11 +24,18 @@ features as a native app for Android, macOS, and Windows.
 Download the package for your platform from
 [Releases](https://github.com/redtidev1918/daviewer/releases):
 
-- **Android**: `DAViewer-<version>.apk`
+- **Android**: `DAViewer-v<version>.apk`
 - **macOS 12+ test preview**:
-  `DAViewer-<version>-macos-unsigned-preview.zip` (universal Intel and Apple
+  `DAViewer-v<version>-macos-unsigned-preview.zip` (universal Intel and Apple
   Silicon build; unzip and drag to Applications)
-- **Windows**: `DAViewer-<version>-windows.zip` (unzip and run `DAViewer.exe`)
+- **Windows**: `DAViewer-v<version>-windows.zip` (unzip and run `DAViewer.exe`)
+
+Exactly one asset is published per platform, always named
+`DAViewer-v<version>-<platform>`. The `v` prefix is part of the naming
+contract. Older releases may still carry a duplicate pair from the previous
+release protocol (e.g. both `DAViewer-0.2.184.apk` and
+`DAViewer-v0.2.184.apk`); those are residue, not the output of the current
+pipeline.
 
 The Windows build is portable: sign-in happens entirely inside the app — it
 never touches system settings, needs no administrator rights, and installs

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@
 
 从 [Releases](https://github.com/redtidev1918/daviewer/releases) 下载对应平台的安装包：
 
-- **Android**：`DAViewer-<版本>.apk`
-- **macOS 12+ 测试版**：`DAViewer-<版本>-macos-unsigned-preview.zip`（同时支持 Intel 与 Apple Silicon；解压后拖入「应用程序」）
-- **Windows**：`DAViewer-<版本>-windows.zip`（解压后运行 `DAViewer.exe`）
+- **Android**：`DAViewer-v<版本>.apk`
+- **macOS 12+ 测试版**：`DAViewer-v<版本>-macos-unsigned-preview.zip`（同时支持 Intel 与 Apple Silicon；解压后拖入「应用程序」）
+- **Windows**：`DAViewer-v<版本>-windows.zip`（解压后运行 `DAViewer.exe`）
+
+每个平台只发布**一个**资产，文件名固定为 `DAViewer-v<版本>-<平台>`；`v` 前缀是命名规范的一部分，
+不是装饰。历史 Release 上可能残留旧协议的重复文件（例如同时存在 `DAViewer-0.2.184.apk` 与
+`DAViewer-v0.2.184.apk`），这只是旧协议留下的遗留物，**不是**当前流水线的产物。
 
 Windows 版解压即用：登录全程在 App 内完成，不会改动系统设置、不需要管理员权限，也不安装任何服务；文件夹移到任何位置都能直接运行。
 


### PR DESCRIPTION
v0.2.184 ships six binaries where there should be three: every platform appears twice, as `DAViewer-0.2.184-*` **and** `DAViewer-v0.2.184-*`.

## Root cause (from asset timestamps, not inspection)

```text
DAViewer-0.2.184*       created 2026-09-06T20:33:18Z   (release published 20:33:21Z)
DAViewer-v0.2.184*      created 2026-09-09T05:40-05:42Z
RELEASE-METADATA.json   created 2026-09-09T05:43:30Z
SHA256SUMS              created 2026-09-09T05:42:19Z
```

The tag was published by the **pre-migration** protocol (v-less names). Three days later #14 ("migrate release protocol to v1") re-processed that same tag and uploaded the canonical v-prefixed assets on top. Release uploads are additive — `_upload_idempotent` adds and never removes — so the old names survived as residue.

**The second uploader is the retired pre-migration pipeline, not a live one.**

## The current pipeline was already canonical — and was left alone

- `scripts/build-release` is the only producer; it writes exactly one `DAViewer-v$RELEASE_VERSION-*` name per platform.
- `.release-policy.yml` scopes collection to `DAViewer-v*.apk` / `DAViewer-v*macos-unsigned-preview.zip` / `DAViewer-v*windows.zip`, so a stray file cannot be collected.

## What was actually wrong: everything that still *teaches* the v-less name

- `README.md` / `README.en.md` documented `DAViewer-<版本>-*` — a filename the canonical pipeline never emits. Now the canonical `v` form, with the contract stated.
- Nothing stopped a future protocol migration from silently re-introducing a second convention — which is precisely how this happened. **CI now guards it**: the producer must emit only canonical names, and the publish policy must require them.

## Deliberately not done

- **No destructive cleanup.** The v0.2.184 duplicates are `HISTORICAL_COSMETIC_DEBT` and stay. Release retention (`stable: 1`) removes that release once a newer one publishes.
- No change to releasegraph, and no change to the docsite-managed `update_download_page.py`.

## Note

`git` in this workspace has a dead `http.proxy` (`127.0.0.1:7892`); pushes here were made with the proxy disabled. Unrelated to this change.

## Verification

Guard semantics checked locally against the actual files (producer has no v-less name, does have canonical names, policy requires `DAViewer-v*`); `ci.yml` parses as valid YAML. Flutter analyze/test run in CI as usual.